### PR TITLE
Harden deployment fail-fast and password handling

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -8,12 +8,6 @@
         # Write-Host is acceptable for user-facing deployment scripts
         'PSAvoidUsingWriteHost',
 
-        # False positive: triggers on parameter names like $userPassword, not hardcoded passwords
-        'PSAvoidUsingPlainTextForPassword',
-
-        # Deployment scripts receive passwords as strings from Read-Host, conversion is unavoidable
-        'PSAvoidUsingConvertToSecureStringWithPlainText',
-
         # Functions like Get-ApplicablePolicies are clearer with plural nouns in this context
         'PSUseSingularNouns'
     )

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ The installer prompts for:
 - **Create user with auto-login?** (dedicated only)
 - **DWService agent code** (optional)
 
+For non-interactive runs, `-userPassword` expects a `SecureString`:
+
+```powershell
+$securePassword = ConvertTo-SecureString 'ReplaceWithDeploymentPassword' -AsPlainText -Force
+& $env:TEMP\install.ps1 -systemPurpose 'radio' -systemOwnership 'shared' -userPassword $securePassword
+```
+
 ### Updating Existing Systems
 
 Use the `-OnlyRun` parameter to selectively run specific scripts on already-deployed systems:

--- a/install.ps1
+++ b/install.ps1
@@ -188,21 +188,24 @@ Write-Output ""
 $validPurposes = @("radio", "tv", "editorial", "plain")
 $validOwnership = @("shared", "personal", "dedicated")
 
-# Script requirements mapping - which parameters each script needs
-$scriptRequirements = @{
-    'debloat'          = @('systemPurpose', 'systemOwnership')
-    'securitybaseline' = @()
-    'applocker'        = @('systemOwnership')
-    'apps'             = @('systemPurpose', 'systemOwnership')
-    'dwservice'        = @('dwAgentCode')
-    'hardening'        = @()
-    'policies'         = @('systemPurpose', 'systemOwnership')
-    'power'            = @('systemPurpose', 'systemOwnership')
-    'sounds'           = @()
-    'time'             = @()
-    'updates'          = @()
-    'users'            = @('systemPurpose', 'systemOwnership', 'userPassword', 'dedicatedUserName', 'personalUserName')
-    'workgroupname'    = @('computerName', 'workgroupName')
+# Derive each script's required params from its param() block; a hand-maintained map drifted and silently broke power.ps1.
+$scriptsDir = Join-Path $deployDir "scripts"
+$scriptRequirements = @{}
+Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
+    Where-Object { $_.BaseName -ne "_common" } |
+    ForEach-Object {
+        $scriptName = $_.BaseName -replace '^_', ''
+        $scriptRequirements[$scriptName] = Get-ScriptParameterNames -Path $_.FullName
+    }
+
+# Reverse-drift check: a script param that install.ps1 cannot supply would otherwise splat $null silently.
+$installerParams = @(Get-ScriptParameterNames -Path $PSCommandPath | Where-Object { $_ -ne 'OnlyRun' })
+foreach ($script in $scriptRequirements.Keys) {
+    foreach ($paramName in $scriptRequirements[$script]) {
+        if ($paramName -notin $installerParams) {
+            Write-FatalInstallError -Message "Script '$script' declares parameter -$paramName but install.ps1 does not collect it. Add it to install.ps1's param() block."
+        }
+    }
 }
 
 # Determine which parameters are required based on -OnlyRun
@@ -302,71 +305,61 @@ Write-Output ""
 # Execute all scripts in the scripts directory
 #===============================================================
 
-$scriptsDir = "$deployDir\scripts"
+if (-not (Test-Path $scriptsDir)) {
+    Write-FatalInstallError -Message "Script directory does not exist: $scriptsDir"
+}
 
-# Check if the scripts directory exists
-if (Test-Path $scriptsDir) {
-    # Get executable .ps1 files in the scripts directory (sorted alphabetically)
-    $scriptFiles = Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
-        Where-Object { $_.BaseName -ne "_common" } |
-        Sort-Object Name
+$allParams = @{
+    systemPurpose     = $systemPurpose
+    systemOwnership   = $systemOwnership
+    userPassword      = $userPassword
+    computerName      = $computerName
+    workgroupName     = $workgroupName
+    dwAgentCode       = $dwAgentCode
+    dedicatedUserName = $dedicatedUserName
+    personalUserName  = $personalUserName
+}
 
-    foreach ($scriptFile in $scriptFiles) {
-        # Get script name without extension and underscore prefix (e.g., "_debloat.ps1" -> "debloat")
-        $scriptName = $scriptFile.BaseName -replace '^_', ''
+$scriptFiles = Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
+    Where-Object { $_.BaseName -ne "_common" } |
+    Sort-Object Name
 
-        # Skip scripts not in -OnlyRun list (if specified)
-        if ($OnlyRun -and $scriptName -notin $OnlyRun) {
-            Write-Output "Skipping: $($scriptFile.Name) (not in -OnlyRun list)"
-            continue
-        }
+foreach ($scriptFile in $scriptFiles) {
+    # Get script name without extension and underscore prefix (e.g., "_debloat.ps1" -> "debloat")
+    $scriptName = $scriptFile.BaseName -replace '^_', ''
 
-        Write-Output ""
-        Write-Output "=========================================="
-        Write-Output "Running: $($scriptFile.Name)"
-        Write-Output "=========================================="
-
-        $allParams = @{
-            systemPurpose     = $systemPurpose
-            systemOwnership   = $systemOwnership
-            userPassword      = $userPassword
-            computerName      = $computerName
-            workgroupName     = $workgroupName
-            dwAgentCode       = $dwAgentCode
-            dedicatedUserName = $dedicatedUserName
-            personalUserName  = $personalUserName
-        }
-
-        $scriptParams = @{}
-        if ($scriptRequirements.ContainsKey($scriptName)) {
-            foreach ($paramName in $scriptRequirements[$scriptName]) {
-                $scriptParams[$paramName] = $allParams[$paramName]
-            }
-        }
-        else {
-            $scriptParams = $allParams
-        }
-
-        try {
-            & $scriptFile.FullName @scriptParams
-        }
-        catch {
-            Write-FatalInstallError -Message "Failed to execute script: $($scriptFile.Name)" -ErrorRecord $_
-        }
+    # Skip scripts not in -OnlyRun list (if specified)
+    if ($OnlyRun -and $scriptName -notin $OnlyRun) {
+        Write-Output "Skipping: $($scriptFile.Name) (not in -OnlyRun list)"
+        continue
     }
 
     Write-Output ""
     Write-Output "=========================================="
-    if ($OnlyRun) {
-        Write-Output "Selected scripts completed: $($OnlyRun -join ', ')"
-    }
-    else {
-        Write-Output "All scripts completed."
-    }
+    Write-Output "Running: $($scriptFile.Name)"
     Write-Output "=========================================="
+
+    $scriptParams = @{}
+    foreach ($paramName in $scriptRequirements[$scriptName]) {
+        $scriptParams[$paramName] = $allParams[$paramName]
+    }
+
+    try {
+        & $scriptFile.FullName @scriptParams
+    }
+    catch {
+        Write-FatalInstallError -Message "Failed to execute script: $($scriptFile.Name)" -ErrorRecord $_
+    }
+}
+
+Write-Output ""
+Write-Output "=========================================="
+if ($OnlyRun) {
+    Write-Output "Selected scripts completed: $($OnlyRun -join ', ')"
 }
 else {
-    Write-FatalInstallError -Message "Script directory does not exist: $scriptsDir"
+    Write-Output "All scripts completed."
 }
+Write-Output "=========================================="
 
 Complete-Install

--- a/install.ps1
+++ b/install.ps1
@@ -28,7 +28,6 @@ function Test-Admin {
 }
 
 $script:InstallLogPath = $null
-$script:InstallTranscriptStarted = $false
 
 function Initialize-InstallLog {
     $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
@@ -43,16 +42,15 @@ function Initialize-InstallLog {
                 New-Item -Path $logDirectory -ItemType Directory -Force | Out-Null
             }
 
-            $script:InstallLogPath = Join-Path $logDirectory "windows11-baseline-$timestamp.log"
-            Start-Transcript -Path $script:InstallLogPath -Force | Out-Null
-            $script:InstallTranscriptStarted = $true
+            $candidate = Join-Path $logDirectory "windows11-baseline-$timestamp.log"
+            Start-Transcript -Path $candidate -Force | Out-Null
+            $script:InstallLogPath = $candidate
+            $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH = $candidate
             Write-Output "Log file: $script:InstallLogPath"
             return
         }
         catch {
             Write-Verbose "Could not start transcript in ${logDirectory}: $($_.Exception.Message)"
-            $script:InstallLogPath = $null
-            $script:InstallTranscriptStarted = $false
         }
     }
 
@@ -60,65 +58,17 @@ function Initialize-InstallLog {
 }
 
 function Close-InstallLog {
-    if ($script:InstallTranscriptStarted) {
-        try {
-            Stop-Transcript | Out-Null
-        }
-        catch {
-            Write-Verbose "Could not stop transcript: $($_.Exception.Message)"
-        }
-        finally {
-            $script:InstallTranscriptStarted = $false
-        }
-    }
-}
-
-function Suspend-InstallLog {
-    if (-not $script:InstallTranscriptStarted) {
-        return $false
-    }
-
-    try {
-        Stop-Transcript | Out-Null
-        $script:InstallTranscriptStarted = $false
-        return $true
-    }
-    catch {
-        throw "Could not suspend transcript before sensitive operation: $($_.Exception.Message)"
-    }
-}
-
-function Resume-InstallLog {
-    param (
-        [bool]$WasStarted
-    )
-
-    if (-not $WasStarted -or -not $script:InstallLogPath) {
+    if (-not $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH) {
         return
     }
-
     try {
-        Start-Transcript -Path $script:InstallLogPath -Append -Force | Out-Null
-        $script:InstallTranscriptStarted = $true
+        Stop-Transcript | Out-Null
     }
     catch {
-        Write-Warning "Could not resume transcript logging: $($_.Exception.Message)"
-        $script:InstallTranscriptStarted = $false
-    }
-}
-
-function Invoke-WithInstallTranscriptSuspended {
-    param (
-        [Parameter(Mandatory)]
-        [scriptblock]$ScriptBlock
-    )
-
-    $wasStarted = Suspend-InstallLog
-    try {
-        & $ScriptBlock
+        Write-Verbose "Could not stop transcript: $($_.Exception.Message)"
     }
     finally {
-        Resume-InstallLog -WasStarted $wasStarted
+        Remove-Item -Path "Env:WINDOWS11_BASELINE_TRANSCRIPT_PATH" -ErrorAction SilentlyContinue
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -27,21 +27,6 @@ function Test-Admin {
     (New-Object Security.Principal.WindowsPrincipal $currentUser).IsInRole($adminRole)
 }
 
-function ConvertFrom-SecureStringToPlainText {
-    param (
-        [Parameter(Mandatory)]
-        [securestring]$SecureString
-    )
-
-    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
-    try {
-        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-    }
-    finally {
-        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-    }
-}
-
 $script:InstallLogPath = $null
 $script:InstallTranscriptStarted = $false
 
@@ -155,6 +140,50 @@ Write-Output ""
 Write-Output "This script will configure a Windows 11 system with the specified settings."
 Write-Output ""
 
+# Download before prompting so we can source _common.ps1 and validate the password input.
+$deployDir = "C:\Windows\deploy"
+$zipUrl = "https://github.com/oszuidwest/windows11-baseline/archive/refs/heads/main.zip"
+$zipFilePath = "$deployDir\main.zip"
+$sourceDir = "$deployDir\windows11-baseline-main"
+
+if (Test-Path $deployDir) {
+    Remove-Item -Path $deployDir -Recurse -Force
+}
+New-Item -Path $deployDir -ItemType Directory -Force | Out-Null
+
+try {
+    Write-Output "Downloading ZIP file from $zipUrl..."
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $zipUrl -OutFile $zipFilePath -UseBasicParsing -ErrorAction Stop
+    Write-Output "Download complete. Extracting ZIP file..."
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFilePath, $deployDir)
+    Write-Output "Extraction complete."
+}
+catch {
+    Write-FatalInstallError -Message "Failed to download or extract ZIP file." -ErrorRecord $_
+}
+
+Remove-Item -Path $zipFilePath -Force
+
+if (Test-Path $sourceDir) {
+    Write-Output "Moving contents from $sourceDir to $deployDir..."
+    Get-ChildItem -Path $sourceDir | Move-Item -Destination $deployDir -Force
+    Remove-Item -Path $sourceDir -Recurse -Force
+    Write-Output "Contents moved and $sourceDir removed."
+}
+else {
+    Write-FatalInstallError -Message "$sourceDir does not exist. Exiting..."
+}
+
+$commonPath = Join-Path $deployDir "scripts\_common.ps1"
+if (-not (Test-Path $commonPath)) {
+    Write-FatalInstallError -Message "Shared helpers not found at $commonPath"
+}
+. $commonPath
+
+Write-Output ""
+
 # Valid options
 $validPurposes = @("radio", "tv", "editorial", "plain")
 $validOwnership = @("shared", "personal", "dedicated")
@@ -168,7 +197,7 @@ $scriptRequirements = @{
     'dwservice'        = @('dwAgentCode')
     'hardening'        = @()
     'policies'         = @('systemPurpose', 'systemOwnership')
-    'power'            = @()
+    'power'            = @('systemPurpose', 'systemOwnership')
     'sounds'           = @()
     'time'             = @()
     'updates'          = @()
@@ -221,12 +250,6 @@ if ('workgroupName' -in $requiredParams -and -not $workgroupName) {
     $workgroupName = Read-Host -Prompt "Enter the workgroup name"
 }
 
-# Get user password (if required and not provided via parameter)
-if ('userPassword' -in $requiredParams -and -not $userPassword) {
-    $secureUserPassword = Read-Host -Prompt "Enter the user password" -AsSecureString
-    $userPassword = ConvertFrom-SecureStringToPlainText -SecureString $secureUserPassword
-}
-
 # For dedicated systems, ask if a user with auto-login should be created
 if ('dedicatedUserName' -in $requiredParams -and -not $dedicatedUserName -and $systemOwnership -eq "dedicated") {
     Write-Output ""
@@ -247,6 +270,25 @@ if ('personalUserName' -in $requiredParams -and -not $personalUserName -and $sys
     } while (-not $personalUserName)
 }
 
+# Resolve account name first so the password prompt can enforce the username-substring rule.
+$plannedUser = Resolve-DeploymentUserName -SystemPurpose $systemPurpose -SystemOwnership $systemOwnership `
+    -DedicatedUserName $dedicatedUserName -PersonalUserName $personalUserName
+
+if ('userPassword' -in $requiredParams -and $plannedUser.UserName) {
+    if ($userPassword) {
+        try {
+            Test-LocalUserPassword -Candidate $userPassword -AccountName $plannedUser.UserName
+        }
+        catch {
+            Write-FatalInstallError -Message "Password supplied via -userPassword does not meet policy: $($_.Exception.Message)"
+        }
+    }
+    else {
+        Write-Output ""
+        $userPassword = Read-DeploymentPassword -AccountName $plannedUser.UserName
+    }
+}
+
 # Get DWService agent code (if required and not provided via parameter)
 if ('dwAgentCode' -in $requiredParams -and -not $dwAgentCode) {
     Write-Output ""
@@ -255,46 +297,6 @@ if ('dwAgentCode' -in $requiredParams -and -not $dwAgentCode) {
 }
 
 Write-Output ""
-
-# Set deployment directory
-$deployDir = "C:\Windows\deploy"
-$zipUrl = "https://github.com/oszuidwest/windows11-baseline/archive/refs/heads/main.zip"
-$zipFilePath = "$deployDir\main.zip"
-$sourceDir = "$deployDir\windows11-baseline-main"
-
-# Clean up and recreate deployment directory
-if (Test-Path $deployDir) {
-    Remove-Item -Path $deployDir -Recurse -Force
-}
-New-Item -Path $deployDir -ItemType Directory -Force
-
-# Download and extract ZIP file
-try {
-    Write-Output "Downloading ZIP file from $zipUrl..."
-    $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri $zipUrl -OutFile $zipFilePath -UseBasicParsing -ErrorAction Stop
-    Write-Output "Download complete. Extracting ZIP file..."
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFilePath, $deployDir)
-    Write-Output "Extraction complete."
-}
-catch {
-    Write-FatalInstallError -Message "Failed to download or extract ZIP file." -ErrorRecord $_
-}
-
-# Clean up the downloaded ZIP file
-Remove-Item -Path $zipFilePath -Force
-
-# Move extracted contents to root of deployDir
-if (Test-Path $sourceDir) {
-    Write-Output "Moving contents from $sourceDir to $deployDir..."
-    Get-ChildItem -Path $sourceDir | Move-Item -Destination $deployDir -Force
-    Remove-Item -Path $sourceDir -Recurse -Force
-    Write-Output "Contents moved and $sourceDir removed."
-}
-else {
-    Write-FatalInstallError -Message "$sourceDir does not exist. Exiting..."
-}
 
 #===============================================================
 # Execute all scripts in the scripts directory

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@ param(
 
     [string]$computerName,
     [string]$workgroupName,
-    [string]$userPassword,
+    [securestring]$userPassword,
     [string]$dwAgentCode,
     [string]$dedicatedUserName,
     [string]$personalUserName,
@@ -70,6 +70,55 @@ function Close-InstallLog {
         finally {
             $script:InstallTranscriptStarted = $false
         }
+    }
+}
+
+function Suspend-InstallLog {
+    if (-not $script:InstallTranscriptStarted) {
+        return $false
+    }
+
+    try {
+        Stop-Transcript | Out-Null
+        $script:InstallTranscriptStarted = $false
+        return $true
+    }
+    catch {
+        throw "Could not suspend transcript before sensitive operation: $($_.Exception.Message)"
+    }
+}
+
+function Resume-InstallLog {
+    param (
+        [bool]$WasStarted
+    )
+
+    if (-not $WasStarted -or -not $script:InstallLogPath) {
+        return
+    }
+
+    try {
+        Start-Transcript -Path $script:InstallLogPath -Append -Force | Out-Null
+        $script:InstallTranscriptStarted = $true
+    }
+    catch {
+        Write-Warning "Could not resume transcript logging: $($_.Exception.Message)"
+        $script:InstallTranscriptStarted = $false
+    }
+}
+
+function Invoke-WithInstallTranscriptSuspended {
+    param (
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock
+    )
+
+    $wasStarted = Suspend-InstallLog
+    try {
+        & $ScriptBlock
+    }
+    finally {
+        Resume-InstallLog -WasStarted $wasStarted
     }
 }
 
@@ -188,15 +237,22 @@ Write-Output ""
 $validPurposes = @("radio", "tv", "editorial", "plain")
 $validOwnership = @("shared", "personal", "dedicated")
 
-# Derive each script's required params from its param() block; a hand-maintained map drifted and silently broke power.ps1.
+# Derive requirements from each script's param() block so prompting and splatting stay in sync.
 $scriptsDir = Join-Path $deployDir "scripts"
+if (-not (Test-Path $scriptsDir)) {
+    Write-FatalInstallError -Message "Script directory does not exist: $scriptsDir"
+}
+
+$scriptFiles = @(Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
+        Where-Object { $_.BaseName -ne "_common" } |
+        Sort-Object Name)
+
 $scriptRequirements = @{}
-Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
-    Where-Object { $_.BaseName -ne "_common" } |
-    ForEach-Object {
-        $scriptName = $_.BaseName -replace '^_', ''
-        $scriptRequirements[$scriptName] = Get-ScriptParameterNames -Path $_.FullName
-    }
+$scriptFiles | ForEach-Object {
+    # Public script names strip a leading ordering underscore: _securitybaseline.ps1 -> securitybaseline.
+    $scriptName = $_.BaseName -replace '^_', ''
+    $scriptRequirements[$scriptName] = Get-ScriptParameterNames -Path $_.FullName
+}
 
 # Reverse-drift check: a script param that install.ps1 cannot supply would otherwise splat $null silently.
 $installerParams = @(Get-ScriptParameterNames -Path $PSCommandPath | Where-Object { $_ -ne 'OnlyRun' })
@@ -280,7 +336,7 @@ $plannedUser = Resolve-DeploymentUserName -SystemPurpose $systemPurpose -SystemO
 if ('userPassword' -in $requiredParams -and $plannedUser.UserName) {
     if ($userPassword) {
         try {
-            Test-LocalUserPassword -Candidate $userPassword -AccountName $plannedUser.UserName
+            Test-LocalUserPassword -SecurePassword $userPassword -AccountName $plannedUser.UserName
         }
         catch {
             Write-FatalInstallError -Message "Password supplied via -userPassword does not meet policy: $($_.Exception.Message)"
@@ -305,10 +361,6 @@ Write-Output ""
 # Execute all scripts in the scripts directory
 #===============================================================
 
-if (-not (Test-Path $scriptsDir)) {
-    Write-FatalInstallError -Message "Script directory does not exist: $scriptsDir"
-}
-
 $allParams = @{
     systemPurpose     = $systemPurpose
     systemOwnership   = $systemOwnership
@@ -320,12 +372,7 @@ $allParams = @{
     personalUserName  = $personalUserName
 }
 
-$scriptFiles = Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
-    Where-Object { $_.BaseName -ne "_common" } |
-    Sort-Object Name
-
 foreach ($scriptFile in $scriptFiles) {
-    # Get script name without extension and underscore prefix (e.g., "_debloat.ps1" -> "debloat")
     $scriptName = $scriptFile.BaseName -replace '^_', ''
 
     # Skip scripts not in -OnlyRun list (if specified)

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -109,3 +109,122 @@ function Invoke-Download {
         $ProgressPreference = $previousProgressPreference
     }
 }
+
+function ConvertFrom-SecureStringToPlainText {
+    param (
+        [Parameter(Mandatory)]
+        [securestring]$SecureString
+    )
+
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
+function Test-LocalUserPassword {
+    param (
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Candidate,
+
+        [Parameter(Mandatory)]
+        [string]$AccountName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Candidate)) {
+        throw "A password is required when creating '$AccountName'."
+    }
+
+    if ($Candidate.Length -lt 8) {
+        throw "The password for '$AccountName' must be at least 8 characters."
+    }
+
+    $characterClasses = 0
+    if ($Candidate -cmatch "[A-Z]") { $characterClasses++ }
+    if ($Candidate -cmatch "[a-z]") { $characterClasses++ }
+    if ($Candidate -match "\d") { $characterClasses++ }
+    if ($Candidate -match "[^a-zA-Z\d]") { $characterClasses++ }
+
+    if ($characterClasses -lt 3) {
+        throw "The password for '$AccountName' must contain characters from at least 3 of these groups: uppercase, lowercase, numbers, symbols."
+    }
+
+    $userNameParts = @($AccountName -split "[\s._-]+" | Where-Object { $_.Length -ge 3 })
+    foreach ($userNamePart in $userNameParts) {
+        if ($Candidate.IndexOf($userNamePart, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            throw "The password for '$AccountName' must not contain username part '$userNamePart'."
+        }
+    }
+}
+
+function Resolve-DeploymentUserName {
+    param (
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$SystemPurpose,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$SystemOwnership,
+
+        [AllowEmptyString()]
+        [string]$DedicatedUserName,
+
+        [AllowEmptyString()]
+        [string]$PersonalUserName
+    )
+
+    $purpose = $SystemPurpose.ToLower()
+    $ownership = $SystemOwnership.ToLower()
+
+    if ($ownership -eq "dedicated" -and $DedicatedUserName) {
+        return [pscustomobject]@{ UserName = $DedicatedUserName; EnableAutoLogin = $true }
+    }
+
+    if ($ownership -eq "personal" -and $PersonalUserName) {
+        return [pscustomobject]@{ UserName = $PersonalUserName; EnableAutoLogin = $false }
+    }
+
+    if ($ownership -eq "shared") {
+        $sharedUserName = switch ($purpose) {
+            'editorial' { "Redactie Gebruiker" }
+            'tv' { "Studio Gebruiker" }
+            'radio' { "Studio Gebruiker" }
+            default { "" }
+        }
+        return [pscustomobject]@{ UserName = $sharedUserName; EnableAutoLogin = ($purpose -ne "plain") }
+    }
+
+    return [pscustomobject]@{ UserName = ""; EnableAutoLogin = $false }
+}
+
+function Read-DeploymentPassword {
+    param (
+        [Parameter(Mandatory)]
+        [string]$AccountName,
+
+        [string]$Prompt = "Enter the user password"
+    )
+
+    Write-Output "Password requirements for '$AccountName':"
+    Write-Output "  - At least 8 characters"
+    Write-Output "  - Characters from at least 3 of: uppercase, lowercase, numbers, symbols"
+    Write-Output "  - Must not contain parts of the username"
+
+    while ($true) {
+        $secure = Read-Host -Prompt $Prompt -AsSecureString
+        $candidate = ConvertFrom-SecureStringToPlainText -SecureString $secure
+        try {
+            Test-LocalUserPassword -Candidate $candidate -AccountName $AccountName
+            return $candidate
+        }
+        catch {
+            Write-Warning $_.Exception.Message
+            Write-Output ""
+        }
+    }
+}

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -110,6 +110,24 @@ function Invoke-Download {
     }
 }
 
+function Get-ScriptParameterNames {
+    [OutputType([string[]])]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$parseErrors)
+    if ($parseErrors) {
+        throw "PowerShell parse errors in $($Path): $($parseErrors -join '; ')"
+    }
+    if (-not $ast.ParamBlock) {
+        return @()
+    }
+    return @($ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath })
+}
+
 function ConvertFrom-SecureStringToPlainText {
     param (
         [Parameter(Mandatory)]

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -209,12 +209,13 @@ function Resolve-DeploymentUserName {
     }
 
     if ($ownership -eq "shared") {
-        $sharedUserName = switch ($purpose) {
-            'editorial' { "Redactie Gebruiker" }
-            'tv' { "Studio Gebruiker" }
-            'radio' { "Studio Gebruiker" }
-            default { "" }
+        $sharedUserNames = @{
+            'editorial' = 'Redactie Gebruiker'
+            'tv'        = 'Studio Gebruiker'
+            'radio'     = 'Studio Gebruiker'
         }
+        $sharedUserName = $sharedUserNames[$purpose]
+        if (-not $sharedUserName) { $sharedUserName = "" }
         return [pscustomobject]@{ UserName = $sharedUserName; EnableAutoLogin = ($purpose -ne "plain") }
     }
 
@@ -245,6 +246,17 @@ function Read-DeploymentPassword {
             Write-Output ""
         }
     }
+}
+
+# WUA orcSucceeded == 2. See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wsusss/0a8c5b85-2123-4ed9-a6cd-7d23e23e3786
+$script:WuaSucceededCode = 2
+
+function Test-WuaSucceeded {
+    param (
+        [Parameter(Mandatory)]
+        [int]$ResultCode
+    )
+    return $ResultCode -eq $script:WuaSucceededCode
 }
 
 function Get-WuaOperationResultName {
@@ -278,17 +290,92 @@ function Get-WuaFailedUpdateDetails {
         $Updates
     )
 
-    $failedUpdates = @()
+    $failedUpdates = [System.Collections.Generic.List[string]]::new()
     for ($idx = 0; $idx -lt $Updates.Count; $idx++) {
         $perUpdateResult = $OperationResult.GetUpdateResult($idx)
         $perUpdateCode = [int]$perUpdateResult.ResultCode
-        if ($perUpdateCode -ne 2) {
+        if (-not (Test-WuaSucceeded -ResultCode $perUpdateCode)) {
             $hresult = "0x{0:X8}" -f ([int]$perUpdateResult.HResult)
             $title = $Updates.Item($idx).Title
             $perUpdateName = Get-WuaOperationResultName -ResultCode $perUpdateCode
-            $failedUpdates += "  - $title ($perUpdateName, HRESULT $hresult)"
+            $failedUpdates.Add("  - $title ($perUpdateName, HRESULT $hresult)")
         }
     }
 
-    return @($failedUpdates)
+    return $failedUpdates.ToArray()
+}
+
+function Assert-WuaOperationSucceeded {
+    param (
+        [Parameter(Mandatory)]
+        $OperationResult,
+
+        [Parameter(Mandatory)]
+        $Updates,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Download', 'Install')]
+        [string]$Phase
+    )
+
+    $code = [int]$OperationResult.ResultCode
+    $name = Get-WuaOperationResultName -ResultCode $code
+    Write-Output "  $Phase operation result: $name ($code)"
+
+    if (Test-WuaSucceeded -ResultCode $code) {
+        return
+    }
+
+    $failedUpdates = Get-WuaFailedUpdateDetails -OperationResult $OperationResult -Updates $Updates
+    $detail = if ($failedUpdates.Count -gt 0) { "`n" + ($failedUpdates -join "`n") } else { "" }
+    throw "Windows Update $($Phase.ToLower()) reported $name ($code).$detail"
+}
+
+# install.ps1 publishes the active transcript path to $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH;
+# child scripts (invoked via &) read it to suspend/resume the parent transcript around plaintext
+# secrets (e.g. registry writes that would otherwise be captured).
+function Suspend-InstallTranscript {
+    if (-not $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH) {
+        return $false
+    }
+    try {
+        Stop-Transcript | Out-Null
+        return $true
+    }
+    catch {
+        throw "Could not suspend transcript before sensitive operation: $($_.Exception.Message)"
+    }
+}
+
+function Resume-InstallTranscript {
+    param (
+        [Parameter(Mandatory)]
+        [bool]$WasSuspended
+    )
+
+    if (-not $WasSuspended -or -not $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH) {
+        return
+    }
+
+    try {
+        Start-Transcript -Path $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH -Append -Force | Out-Null
+    }
+    catch {
+        Write-Warning "Could not resume transcript logging: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-WithTranscriptSuspended {
+    param (
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock
+    )
+
+    $wasSuspended = Suspend-InstallTranscript
+    try {
+        & $ScriptBlock
+    }
+    finally {
+        Resume-InstallTranscript -WasSuspended $wasSuspended
+    }
 }

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -146,26 +146,27 @@ function ConvertFrom-SecureStringToPlainText {
 function Test-LocalUserPassword {
     param (
         [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string]$Candidate,
+        [securestring]$SecurePassword,
 
         [Parameter(Mandatory)]
         [string]$AccountName
     )
 
-    if ([string]::IsNullOrWhiteSpace($Candidate)) {
+    $plainPassword = ConvertFrom-SecureStringToPlainText -SecureString $SecurePassword
+
+    if ([string]::IsNullOrWhiteSpace($plainPassword)) {
         throw "A password is required when creating '$AccountName'."
     }
 
-    if ($Candidate.Length -lt 8) {
+    if ($plainPassword.Length -lt 8) {
         throw "The password for '$AccountName' must be at least 8 characters."
     }
 
     $characterClasses = 0
-    if ($Candidate -cmatch "[A-Z]") { $characterClasses++ }
-    if ($Candidate -cmatch "[a-z]") { $characterClasses++ }
-    if ($Candidate -match "\d") { $characterClasses++ }
-    if ($Candidate -match "[^a-zA-Z\d]") { $characterClasses++ }
+    if ($plainPassword -cmatch "[A-Z]") { $characterClasses++ }
+    if ($plainPassword -cmatch "[a-z]") { $characterClasses++ }
+    if ($plainPassword -match "\d") { $characterClasses++ }
+    if ($plainPassword -match "[^a-zA-Z\d]") { $characterClasses++ }
 
     if ($characterClasses -lt 3) {
         throw "The password for '$AccountName' must contain characters from at least 3 of these groups: uppercase, lowercase, numbers, symbols."
@@ -173,7 +174,7 @@ function Test-LocalUserPassword {
 
     $userNameParts = @($AccountName -split "[\s._-]+" | Where-Object { $_.Length -ge 3 })
     foreach ($userNamePart in $userNameParts) {
-        if ($Candidate.IndexOf($userNamePart, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+        if ($plainPassword.IndexOf($userNamePart, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
             throw "The password for '$AccountName' must not contain username part '$userNamePart'."
         }
     }
@@ -234,15 +235,60 @@ function Read-DeploymentPassword {
     Write-Output "  - Must not contain parts of the username"
 
     while ($true) {
-        $secure = Read-Host -Prompt $Prompt -AsSecureString
-        $candidate = ConvertFrom-SecureStringToPlainText -SecureString $secure
+        $securePassword = Read-Host -Prompt $Prompt -AsSecureString
         try {
-            Test-LocalUserPassword -Candidate $candidate -AccountName $AccountName
-            return $candidate
+            Test-LocalUserPassword -SecurePassword $securePassword -AccountName $AccountName
+            return $securePassword
         }
         catch {
             Write-Warning $_.Exception.Message
             Write-Output ""
         }
     }
+}
+
+function Get-WuaOperationResultName {
+    param (
+        [Parameter(Mandatory)]
+        [int]$ResultCode
+    )
+
+    $resultCodeNames = @{
+        0 = 'NotStarted'
+        1 = 'InProgress'
+        2 = 'Succeeded'
+        3 = 'SucceededWithErrors'
+        4 = 'Failed'
+        5 = 'Aborted'
+    }
+
+    $resultName = $resultCodeNames[$ResultCode]
+    if (-not $resultName) {
+        return "Unknown($ResultCode)"
+    }
+    return $resultName
+}
+
+function Get-WuaFailedUpdateDetails {
+    param (
+        [Parameter(Mandatory)]
+        $OperationResult,
+
+        [Parameter(Mandatory)]
+        $Updates
+    )
+
+    $failedUpdates = @()
+    for ($idx = 0; $idx -lt $Updates.Count; $idx++) {
+        $perUpdateResult = $OperationResult.GetUpdateResult($idx)
+        $perUpdateCode = [int]$perUpdateResult.ResultCode
+        if ($perUpdateCode -ne 2) {
+            $hresult = "0x{0:X8}" -f ([int]$perUpdateResult.HResult)
+            $title = $Updates.Item($idx).Title
+            $perUpdateName = Get-WuaOperationResultName -ResultCode $perUpdateCode
+            $failedUpdates += "  - $title ($perUpdateName, HRESULT $hresult)"
+        }
+    }
+
+    return @($failedUpdates)
 }

--- a/scripts/applocker.ps1
+++ b/scripts/applocker.ps1
@@ -284,8 +284,8 @@ if (-not $policy -or -not $policy.RuleCollections) {
 
 $exeRules = $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Exe" }
 $appxRules = $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Appx" }
-$exeRuleCount = if ($exeRules) { ($exeRules | Measure-Object -Property Count -Sum).Sum } else { 0 }
-$appxRuleCount = if ($appxRules) { ($appxRules | Measure-Object -Property Count -Sum).Sum } else { 0 }
+$exeRuleCount = if ($exeRules) { ($exeRules | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum } else { 0 }
+$appxRuleCount = if ($appxRules) { ($appxRules | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum } else { 0 }
 
 Write-Output "  Executable rules: $exeRuleCount"
 Write-Output "  Packaged app rules: $appxRuleCount"

--- a/scripts/applocker.ps1
+++ b/scripts/applocker.ps1
@@ -221,43 +221,34 @@ Write-Output ""
 # Step 1: Enable and start the Application Identity service
 Write-Output "Enabling Application Identity service (AppIdSvc)..."
 
-try {
-    # Set service to start automatically using sc.exe (more reliable than Set-Service)
-    try {
-        Invoke-NativeCommand -FilePath "sc.exe" `
-            -Arguments @("config", "AppIDSvc", "start=", "auto") `
-            -FailureMessage "Failed to set AppIDSvc startup type" | Out-Null
-        Write-Output "  Service startup type set to Automatic"
-    }
-    catch {
-        Write-Warning $_.Exception.Message
-    }
+$service = Get-Service -Name "AppIDSvc" -ErrorAction SilentlyContinue
+if (-not $service) {
+    throw "AppIDSvc service not present on this system. AppLocker cannot be enforced without it (requires Windows Enterprise/Education/LTSC)."
+}
 
-    # Start the service if not running
-    $service = Get-Service -Name "AppIDSvc" -ErrorAction SilentlyContinue
-    if ($service -and $service.Status -ne "Running") {
-        Invoke-NativeCommand -FilePath "sc.exe" `
-            -Arguments @("start", "AppIDSvc") `
-            -FailureMessage "Failed to start AppIDSvc" | Out-Null
+Invoke-NativeCommand -FilePath "sc.exe" `
+    -Arguments @("config", "AppIDSvc", "start=", "auto") `
+    -FailureMessage "Failed to set AppIDSvc startup type to Automatic" | Out-Null
+Write-Output "  Service startup type set to Automatic"
+
+if ($service.Status -ne "Running") {
+    Invoke-NativeCommand -FilePath "sc.exe" `
+        -Arguments @("start", "AppIDSvc") `
+        -FailureMessage "Failed to start AppIDSvc" | Out-Null
+
+    $deadline = (Get-Date).AddSeconds(30)
+    do {
         Start-Sleep -Seconds 2
         $service = Get-Service -Name "AppIDSvc"
-        if ($service.Status -eq "Running") {
-            Write-Output "  Service started successfully"
-        }
-        else {
-            Write-Warning "Service may not have started. Status: $($service.Status)"
-        }
+    } while ($service.Status -ne "Running" -and (Get-Date) -lt $deadline)
+
+    if ($service.Status -ne "Running") {
+        throw "AppIDSvc did not reach Running state within 30 seconds (current status: $($service.Status)). AppLocker rules would not be enforced."
     }
-    elseif ($service) {
-        Write-Output "  Service is already running"
-    }
-    else {
-        Write-Warning "AppIDSvc service not found"
-    }
+    Write-Output "  Service started successfully"
 }
-catch {
-    Write-Warning "Failed to configure AppIdSvc service: $_"
-    Write-Warning "AppLocker policies may not be enforced without this service"
+else {
+    Write-Output "  Service is already running"
 }
 
 Write-Output ""
@@ -282,15 +273,32 @@ Write-Output "Verifying AppLocker policy..."
 
 try {
     $policy = Get-AppLockerPolicy -Local -ErrorAction Stop
-    $exeRuleCount = ($policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Exe" }).Count
-    $appxRuleCount = ($policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Appx" }).Count
-
-    Write-Output "  Policy loaded successfully"
-    Write-Output "  Executable rule collections: $exeRuleCount"
-    Write-Output "  Packaged app rule collections: $appxRuleCount"
 }
 catch {
-    Write-Warning "Could not verify policy: $_"
+    throw "Could not read back local AppLocker policy after apply: $($_.Exception.Message)"
+}
+
+if (-not $policy -or -not $policy.RuleCollections) {
+    throw "Local AppLocker policy is empty after apply; enforcement would silently no-op."
+}
+
+$exeRules = $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Exe" }
+$appxRules = $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Appx" }
+$exeRuleCount = if ($exeRules) { ($exeRules | Measure-Object -Property Count -Sum).Sum } else { 0 }
+$appxRuleCount = if ($appxRules) { ($appxRules | Measure-Object -Property Count -Sum).Sum } else { 0 }
+
+Write-Output "  Executable rules: $exeRuleCount"
+Write-Output "  Packaged app rules: $appxRuleCount"
+
+if ($exeRuleCount -eq 0 -or $appxRuleCount -eq 0) {
+    throw "AppLocker policy applied but rule counts are empty (Exe=$exeRuleCount, Appx=$appxRuleCount); enforcement would silently no-op."
+}
+
+$managedCollections = @($policy.RuleCollections | Where-Object { $_.RuleCollectionType -in @("Exe", "Appx") })
+$nonEnforced = @($managedCollections | Where-Object { $_.EnforcementMode -ne "Enabled" })
+if ($nonEnforced.Count -gt 0) {
+    $modes = ($nonEnforced | ForEach-Object { "$($_.RuleCollectionType)=$($_.EnforcementMode)" }) -join ", "
+    throw "AppLocker rule collections not in Enabled enforcement mode: $modes. Rules would log but not block."
 }
 
 Write-Output ""

--- a/scripts/apps.ps1
+++ b/scripts/apps.ps1
@@ -139,6 +139,14 @@ Write-Output "Installing apps for '$systemPurpose'..."
 
 $failedApps = [System.Collections.Generic.List[string]]::new()
 
+# `winget install` exit codes that mean "no-op, package already in the requested state".
+# Treated as success so `-OnlyRun apps` is idempotent on already-deployed workstations.
+# Codes verified against microsoft/winget-cli AppInstallerErrors.h:
+#   0x8A15002B UPDATE_NOT_APPLICABLE       (-1978335189) - winget itself
+#   0x8A150061 PACKAGE_ALREADY_INSTALLED   (-1978335135) - winget itself
+#   0x8A15010D INSTALL_ALREADY_INSTALLED   (-1978334963) - underlying MSI/EXE installer
+$wingetSuccessExitCodes = @(0, -1978335189, -1978335135, -1978334963)
+
 # Install apps via winget
 foreach ($app in $apps) {
     # Skip special apps (handled separately)
@@ -156,6 +164,7 @@ foreach ($app in $apps) {
     try {
         Invoke-NativeCommand -FilePath "winget" `
             -Arguments @("install", "--id=$packageId", "-e", "--silent", "--source", "winget", "--accept-package-agreements", "--accept-source-agreements") `
+            -SuccessExitCodes $wingetSuccessExitCodes `
             -FailureMessage "Failed to install $app" | Out-Null
     }
     catch {
@@ -209,11 +218,11 @@ if ($apps -contains "office") {
     $odtUrl = "https://download.microsoft.com/download/6c1eeb25-cf8b-41d9-8d0d-cc1dbc032140/officedeploymenttool_19628-20046.exe"
     $tempDir = Join-Path $env:TEMP "odt-install"
 
-    if (-not (Test-Path $officeConfigPath)) {
-        throw "Office config file not found at $officeConfigPath (deployment package is incomplete)."
-    }
-
     try {
+        if (-not (Test-Path $officeConfigPath)) {
+            throw "Office config file not found at $officeConfigPath (deployment package is incomplete)."
+        }
+
         New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
         Write-Output "  Downloading Office Deployment Tool..."

--- a/scripts/apps.ps1
+++ b/scripts/apps.ps1
@@ -137,6 +137,8 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
 
 Write-Output "Installing apps for '$systemPurpose'..."
 
+$failedApps = [System.Collections.Generic.List[string]]::new()
+
 # Install apps via winget
 foreach ($app in $apps) {
     # Skip special apps (handled separately)
@@ -147,8 +149,7 @@ foreach ($app in $apps) {
     $packageId = $appDefinitions[$app]
 
     if (-not $packageId) {
-        Write-Warning "Skipping '$app': not defined"
-        continue
+        throw "App '$app' is selected for purpose '$systemPurpose' but is not defined in the app catalog. This is a baseline bug; add it to either the winget definitions or the special-installer list."
     }
 
     Write-Output "Installing $app ($packageId)..."
@@ -159,6 +160,7 @@ foreach ($app in $apps) {
     }
     catch {
         Write-Warning $_.Exception.Message
+        $failedApps.Add($app)
     }
 }
 
@@ -170,32 +172,29 @@ if ($apps -contains "spotify") {
     $spotifyPath = "C:\Program Files\Spotify"
 
     try {
-        # Download Spotify installer
         Write-Output "  Downloading Spotify installer..."
         Invoke-Download -Uri "https://download.spotify.com/SpotifyFullSetup.exe" -OutFile $spotifyInstaller
 
-        # Extract to Program Files (machine-wide installation)
         Write-Output "  Extracting to $spotifyPath..."
         $process = Start-Process -FilePath $spotifyInstaller -ArgumentList "/extract `"$spotifyPath`"" -NoNewWindow -Wait -PassThru
 
-        if ($process.ExitCode -eq 0) {
-            Write-Output "  Spotify installed successfully"
-
-            # Create shortcuts
-            New-Shortcut -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Spotify.lnk" `
-                -TargetPath "$spotifyPath\Spotify.exe" -WorkingDirectory $spotifyPath -Description "Spotify"
-            Write-Output "  Start Menu shortcut created"
-
-            New-Shortcut -Path "C:\Users\Public\Desktop\Spotify.lnk" `
-                -TargetPath "$spotifyPath\Spotify.exe" -WorkingDirectory $spotifyPath -Description "Spotify"
-            Write-Output "  Desktop shortcut created"
+        if ($process.ExitCode -ne 0) {
+            throw "Spotify installer returned exit code $($process.ExitCode)."
         }
-        else {
-            Write-Warning "Spotify installation failed (exit code: $($process.ExitCode))"
-        }
+
+        Write-Output "  Spotify installed successfully"
+
+        New-Shortcut -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Spotify.lnk" `
+            -TargetPath "$spotifyPath\Spotify.exe" -WorkingDirectory $spotifyPath -Description "Spotify"
+        Write-Output "  Start Menu shortcut created"
+
+        New-Shortcut -Path "C:\Users\Public\Desktop\Spotify.lnk" `
+            -TargetPath "$spotifyPath\Spotify.exe" -WorkingDirectory $spotifyPath -Description "Spotify"
+        Write-Output "  Desktop shortcut created"
     }
     catch {
-        Write-Warning "Failed to install Spotify: $_"
+        Write-Warning "Failed to install Spotify: $($_.Exception.Message)"
+        $failedApps.Add("spotify")
     }
     finally {
         Remove-Item -Path $spotifyInstaller -Force -ErrorAction SilentlyContinue
@@ -211,39 +210,39 @@ if ($apps -contains "office") {
     $tempDir = Join-Path $env:TEMP "odt-install"
 
     if (-not (Test-Path $officeConfigPath)) {
-        Write-Warning "Office config file not found at $officeConfigPath"
+        throw "Office config file not found at $officeConfigPath (deployment package is incomplete)."
     }
-    else {
-        try {
-            # Create temp directory
-            New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
-            # Download Office Deployment Tool
-            Write-Output "  Downloading Office Deployment Tool..."
-            $odtExe = Join-Path $tempDir "odt.exe"
-            Invoke-Download -Uri $odtUrl -OutFile $odtExe
+    try {
+        New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
-            # Extract ODT (contains setup.exe)
-            Write-Output "  Extracting ODT..."
-            Invoke-NativeCommand -FilePath $odtExe `
-                -Arguments @("/extract:$tempDir", "/quiet") `
-                -FailureMessage "Failed to extract Office Deployment Tool" | Out-Null
+        Write-Output "  Downloading Office Deployment Tool..."
+        $odtExe = Join-Path $tempDir "odt.exe"
+        Invoke-Download -Uri $odtUrl -OutFile $odtExe
 
-            # Run setup.exe with config
-            $setupExe = Join-Path $tempDir "setup.exe"
-            Write-Output "  Running Office setup..."
-            Invoke-NativeCommand -FilePath $setupExe `
-                -Arguments @("/configure", $officeConfigPath) `
-                -FailureMessage "Failed to install Microsoft Office" | Out-Null
-            Write-Output "  Microsoft Office installed successfully"
-        }
-        catch {
-            Write-Warning "Failed to install Microsoft Office: $_"
-        }
-        finally {
-            Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-        }
+        Write-Output "  Extracting ODT..."
+        Invoke-NativeCommand -FilePath $odtExe `
+            -Arguments @("/extract:$tempDir", "/quiet") `
+            -FailureMessage "Failed to extract Office Deployment Tool" | Out-Null
+
+        $setupExe = Join-Path $tempDir "setup.exe"
+        Write-Output "  Running Office setup..."
+        Invoke-NativeCommand -FilePath $setupExe `
+            -Arguments @("/configure", $officeConfigPath) `
+            -FailureMessage "Failed to install Microsoft Office" | Out-Null
+        Write-Output "  Microsoft Office installed successfully"
     }
+    catch {
+        Write-Warning "Failed to install Microsoft Office: $($_.Exception.Message)"
+        $failedApps.Add("office")
+    }
+    finally {
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($failedApps.Count -gt 0) {
+    throw "App installation failed for: $($failedApps -join ', '). The workstation is not deployment-ready for '$systemPurpose'; re-run with -OnlyRun apps after investigating."
 }
 
 Write-Output "Installation complete."

--- a/scripts/apps.ps1
+++ b/scripts/apps.ps1
@@ -101,7 +101,7 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
         $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" }
         Write-Output "  Installing dependencies for $arch..."
         Get-ChildItem -Path (Join-Path $depsDir $arch) -Filter "*.appx" | ForEach-Object {
-            Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+            Add-AppxPackage -Path $_.FullName -ErrorAction Stop
         }
 
         # Download winget msixbundle and license
@@ -168,8 +168,7 @@ foreach ($app in $apps) {
             -FailureMessage "Failed to install $app" | Out-Null
     }
     catch {
-        Write-Warning $_.Exception.Message
-        $failedApps.Add($app)
+        $failedApps.Add("$app ($($_.Exception.Message))")
     }
 }
 
@@ -202,8 +201,7 @@ if ($apps -contains "spotify") {
         Write-Output "  Desktop shortcut created"
     }
     catch {
-        Write-Warning "Failed to install Spotify: $($_.Exception.Message)"
-        $failedApps.Add("spotify")
+        $failedApps.Add("spotify ($($_.Exception.Message))")
     }
     finally {
         Remove-Item -Path $spotifyInstaller -Force -ErrorAction SilentlyContinue
@@ -242,8 +240,7 @@ if ($apps -contains "office") {
         Write-Output "  Microsoft Office installed successfully"
     }
     catch {
-        Write-Warning "Failed to install Microsoft Office: $($_.Exception.Message)"
-        $failedApps.Add("office")
+        $failedApps.Add("office ($($_.Exception.Message))")
     }
     finally {
         Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -251,10 +248,8 @@ if ($apps -contains "office") {
 }
 
 if ($failedApps.Count -gt 0) {
-    throw "App installation failed for: $($failedApps -join ', '). The workstation is not deployment-ready for '$systemPurpose'; re-run with -OnlyRun apps after investigating."
+    throw "App installation failed for: $($failedApps -join '; '). The workstation is not deployment-ready for '$systemPurpose'; re-run with -OnlyRun apps after investigating."
 }
-
-Write-Output "Installation complete."
 
 # Create WhatsApp Web shortcut (InPrivate mode) for shared computers
 if ($systemOwnership -eq "shared") {
@@ -284,3 +279,5 @@ if ($systemOwnership -eq "shared") {
 
     Write-Output "WhatsApp Web shortcut created on Public Desktop."
 }
+
+Write-Output "Installation complete."

--- a/scripts/dwservice.ps1
+++ b/scripts/dwservice.ps1
@@ -43,34 +43,40 @@ catch {
 
 # Install DWService silently with agent code
 Write-Output "Installing DWService with agent code..."
+$maxMinutes = 5
 try {
     $process = Start-Process -FilePath $installerPath -ArgumentList "-silent", "key=$dwAgentCode" -PassThru
     Write-Output "  Installer started (PID: $($process.Id))"
 
-    # Poll every 60 seconds, max 5 minutes
-    $maxMinutes = 5
     for ($i = 1; $i -le $maxMinutes; $i++) {
-        $exited = $process.WaitForExit(60000)
-
-        if ($exited) {
-            Write-Output "  Installer exited with code: $($process.ExitCode)"
+        if ($process.WaitForExit(60000)) {
             break
         }
-        else {
-            Write-Output "  Still running after $i minute(s)..."
-        }
+        Write-Output "  Still running after $i minute(s)..."
     }
 
     if (-not $process.HasExited) {
-        Write-Warning "Installer still running after $maxMinutes minutes, killing process..."
-        $process.Kill()
+        $killed = $true
+        try {
+            $process.Kill()
+        }
+        catch {
+            $killed = $false
+            Write-Warning "Could not kill DWService installer (PID $($process.Id)): $($_.Exception.Message)"
+        }
+        $killState = if ($killed) { "process was killed" } else { "kill attempt failed (PID $($process.Id) may still be running)" }
+        throw "DWService installer did not exit within $maxMinutes minutes; $killState."
+    }
+
+    $exitCode = $process.ExitCode
+    Write-Output "  Installer exited with code: $exitCode"
+
+    if ($exitCode -ne 0) {
+        throw "DWService installer returned non-zero exit code $exitCode."
     }
 }
-catch {
-    throw "Failed to install DWService: $($_.Exception.Message)"
+finally {
+    Remove-Item -Path $installerPath -Force -ErrorAction SilentlyContinue
 }
-
-# Clean up installer
-Remove-Item -Path $installerPath -Force -ErrorAction SilentlyContinue
 
 Write-Output "DWService installation complete."

--- a/scripts/updates.ps1
+++ b/scripts/updates.ps1
@@ -1,5 +1,7 @@
 param()
 
+. (Join-Path $PSScriptRoot "_common.ps1")
+
 <#
 .SYNOPSIS
     Checks for and installs Windows updates.
@@ -13,16 +15,6 @@ param()
 #>
 
 Write-Output "Checking for Windows updates..."
-
-# WUA OperationResultCode: 0=NotStarted, 1=InProgress, 2=Succeeded, 3=SucceededWithErrors, 4=Failed, 5=Aborted
-$resultCodeNames = @{
-    0 = 'NotStarted'
-    1 = 'InProgress'
-    2 = 'Succeeded'
-    3 = 'SucceededWithErrors'
-    4 = 'Failed'
-    5 = 'Aborted'
-}
 
 # Create Windows Update Session
 $updateSession = New-Object -ComObject Microsoft.Update.Session
@@ -71,25 +63,12 @@ if ($updatesToDownload.Count -gt 0) {
     }
 
     $downloadCode = [int]$downloadResult.ResultCode
-    $downloadName = $resultCodeNames[$downloadCode]
-    if (-not $downloadName) { $downloadName = "Unknown($downloadCode)" }
+    $downloadName = Get-WuaOperationResultName -ResultCode $downloadCode
     Write-Output "  Download operation result: $downloadName ($downloadCode)"
 
     if ($downloadCode -ne 2) {
-        $failedTitles = @()
-        for ($idx = 0; $idx -lt $updatesToDownload.Count; $idx++) {
-            $perResult = $downloadResult.GetUpdateResult($idx)
-            $perCode = [int]$perResult.ResultCode
-            if ($perCode -ne 2) {
-                $hresult = "0x{0:X8}" -f ([int]$perResult.HResult)
-                $title = $updatesToDownload.Item($idx).Title
-                $perName = $resultCodeNames[$perCode]
-                if (-not $perName) { $perName = "Unknown($perCode)" }
-                $failedTitles += "  - $title ($perName, HRESULT $hresult)"
-            }
-        }
-
-        $detail = if ($failedTitles.Count -gt 0) { "`n" + ($failedTitles -join "`n") } else { "" }
+        $failedUpdates = @(Get-WuaFailedUpdateDetails -OperationResult $downloadResult -Updates $updatesToDownload)
+        $detail = if ($failedUpdates.Count -gt 0) { "`n" + ($failedUpdates -join "`n") } else { "" }
         throw "Windows Update download reported $downloadName ($downloadCode).$detail"
     }
 
@@ -128,25 +107,12 @@ if ($updatesToInstall.Count -gt 0) {
     }
 
     $resultCode = [int]$installResult.ResultCode
-    $resultName = $resultCodeNames[$resultCode]
-    if (-not $resultName) { $resultName = "Unknown($resultCode)" }
+    $resultName = Get-WuaOperationResultName -ResultCode $resultCode
     Write-Output "  Install operation result: $resultName ($resultCode)"
 
     if ($resultCode -ne 2) {
-        $failedTitles = @()
-        for ($idx = 0; $idx -lt $updatesToInstall.Count; $idx++) {
-            $perResult = $installResult.GetUpdateResult($idx)
-            $perCode = [int]$perResult.ResultCode
-            if ($perCode -ne 2) {
-                $hresult = "0x{0:X8}" -f ([int]$perResult.HResult)
-                $title = $updatesToInstall.Item($idx).Title
-                $perName = $resultCodeNames[$perCode]
-                if (-not $perName) { $perName = "Unknown($perCode)" }
-                $failedTitles += "  - $title ($perName, HRESULT $hresult)"
-            }
-        }
-
-        $detail = if ($failedTitles.Count -gt 0) { "`n" + ($failedTitles -join "`n") } else { "" }
+        $failedUpdates = @(Get-WuaFailedUpdateDetails -OperationResult $installResult -Updates $updatesToInstall)
+        $detail = if ($failedUpdates.Count -gt 0) { "`n" + ($failedUpdates -join "`n") } else { "" }
         throw "Windows Update install reported $resultName ($resultCode).$detail"
     }
 

--- a/scripts/updates.ps1
+++ b/scripts/updates.ps1
@@ -62,15 +62,7 @@ if ($updatesToDownload.Count -gt 0) {
         throw "Windows Update download failed: $($_.Exception.Message)"
     }
 
-    $downloadCode = [int]$downloadResult.ResultCode
-    $downloadName = Get-WuaOperationResultName -ResultCode $downloadCode
-    Write-Output "  Download operation result: $downloadName ($downloadCode)"
-
-    if ($downloadCode -ne 2) {
-        $failedUpdates = @(Get-WuaFailedUpdateDetails -OperationResult $downloadResult -Updates $updatesToDownload)
-        $detail = if ($failedUpdates.Count -gt 0) { "`n" + ($failedUpdates -join "`n") } else { "" }
-        throw "Windows Update download reported $downloadName ($downloadCode).$detail"
-    }
+    Assert-WuaOperationSucceeded -OperationResult $downloadResult -Updates $updatesToDownload -Phase 'Download'
 
     $downloadedCount = 0
     for ($idx = 0; $idx -lt $updatesToDownload.Count; $idx++) {
@@ -106,15 +98,7 @@ if ($updatesToInstall.Count -gt 0) {
         throw "Windows Update install call failed: $($_.Exception.Message)"
     }
 
-    $resultCode = [int]$installResult.ResultCode
-    $resultName = Get-WuaOperationResultName -ResultCode $resultCode
-    Write-Output "  Install operation result: $resultName ($resultCode)"
-
-    if ($resultCode -ne 2) {
-        $failedUpdates = @(Get-WuaFailedUpdateDetails -OperationResult $installResult -Updates $updatesToInstall)
-        $detail = if ($failedUpdates.Count -gt 0) { "`n" + ($failedUpdates -join "`n") } else { "" }
-        throw "Windows Update install reported $resultName ($resultCode).$detail"
-    }
+    Assert-WuaOperationSucceeded -OperationResult $installResult -Updates $updatesToInstall -Phase 'Install'
 
     if ($installResult.RebootRequired) {
         Write-Output ""

--- a/scripts/updates.ps1
+++ b/scripts/updates.ps1
@@ -14,6 +14,16 @@ param()
 
 Write-Output "Checking for Windows updates..."
 
+# WUA OperationResultCode: 0=NotStarted, 1=InProgress, 2=Succeeded, 3=SucceededWithErrors, 4=Failed, 5=Aborted
+$resultCodeNames = @{
+    0 = 'NotStarted'
+    1 = 'InProgress'
+    2 = 'Succeeded'
+    3 = 'SucceededWithErrors'
+    4 = 'Failed'
+    5 = 'Aborted'
+}
+
 # Create Windows Update Session
 $updateSession = New-Object -ComObject Microsoft.Update.Session
 $updateSearcher = $updateSession.CreateUpdateSearcher()
@@ -54,11 +64,33 @@ if ($updatesToDownload.Count -gt 0) {
     $downloader = $updateSession.CreateUpdateDownloader()
     $downloader.Updates = $updatesToDownload
     try {
-        $downloader.Download() | Out-Null
-        Write-Output "  Download call returned."
+        $downloadResult = $downloader.Download()
     }
     catch {
         throw "Windows Update download failed: $($_.Exception.Message)"
+    }
+
+    $downloadCode = [int]$downloadResult.ResultCode
+    $downloadName = $resultCodeNames[$downloadCode]
+    if (-not $downloadName) { $downloadName = "Unknown($downloadCode)" }
+    Write-Output "  Download operation result: $downloadName ($downloadCode)"
+
+    if ($downloadCode -ne 2) {
+        $failedTitles = @()
+        for ($idx = 0; $idx -lt $updatesToDownload.Count; $idx++) {
+            $perResult = $downloadResult.GetUpdateResult($idx)
+            $perCode = [int]$perResult.ResultCode
+            if ($perCode -ne 2) {
+                $hresult = "0x{0:X8}" -f ([int]$perResult.HResult)
+                $title = $updatesToDownload.Item($idx).Title
+                $perName = $resultCodeNames[$perCode]
+                if (-not $perName) { $perName = "Unknown($perCode)" }
+                $failedTitles += "  - $title ($perName, HRESULT $hresult)"
+            }
+        }
+
+        $detail = if ($failedTitles.Count -gt 0) { "`n" + ($failedTitles -join "`n") } else { "" }
+        throw "Windows Update download reported $downloadName ($downloadCode).$detail"
     }
 
     $downloadedCount = 0
@@ -80,16 +112,6 @@ foreach ($update in $updates) {
     if ($update.IsDownloaded) {
         $updatesToInstall.Add($update) | Out-Null
     }
-}
-
-# WUA OperationResultCode: 0=NotStarted, 1=InProgress, 2=Succeeded, 3=SucceededWithErrors, 4=Failed, 5=Aborted
-$resultCodeNames = @{
-    0 = 'NotStarted'
-    1 = 'InProgress'
-    2 = 'Succeeded'
-    3 = 'SucceededWithErrors'
-    4 = 'Failed'
-    5 = 'Aborted'
 }
 
 # Install updates

--- a/scripts/updates.ps1
+++ b/scripts/updates.ps1
@@ -55,11 +55,23 @@ if ($updatesToDownload.Count -gt 0) {
     $downloader.Updates = $updatesToDownload
     try {
         $downloader.Download() | Out-Null
-        Write-Output "  Download complete."
+        Write-Output "  Download call returned."
     }
     catch {
-        Write-Warning "Download failed: $_"
+        throw "Windows Update download failed: $($_.Exception.Message)"
     }
+
+    $downloadedCount = 0
+    for ($idx = 0; $idx -lt $updatesToDownload.Count; $idx++) {
+        if ($updatesToDownload.Item($idx).IsDownloaded) {
+            $downloadedCount++
+        }
+    }
+    $missingCount = $updatesToDownload.Count - $downloadedCount
+    if ($missingCount -gt 0) {
+        throw "Windows Update reported $missingCount of $($updatesToDownload.Count) update(s) failed to download; refusing to install a partial set."
+    }
+    Write-Output "  All $downloadedCount update(s) downloaded."
 }
 
 # Create update collection for installation
@@ -70,6 +82,16 @@ foreach ($update in $updates) {
     }
 }
 
+# WUA OperationResultCode: 0=NotStarted, 1=InProgress, 2=Succeeded, 3=SucceededWithErrors, 4=Failed, 5=Aborted
+$resultCodeNames = @{
+    0 = 'NotStarted'
+    1 = 'InProgress'
+    2 = 'Succeeded'
+    3 = 'SucceededWithErrors'
+    4 = 'Failed'
+    5 = 'Aborted'
+}
+
 # Install updates
 if ($updatesToInstall.Count -gt 0) {
     Write-Output ""
@@ -78,17 +100,37 @@ if ($updatesToInstall.Count -gt 0) {
     $installer.Updates = $updatesToInstall
     try {
         $installResult = $installer.Install()
-
-        Write-Output "  Installation complete."
-        Write-Output "  Result code: $($installResult.ResultCode)"
-
-        if ($installResult.RebootRequired) {
-            Write-Output ""
-            Write-Warning "A reboot is required to complete the update installation."
-        }
     }
     catch {
-        throw "Installation failed: $($_.Exception.Message)"
+        throw "Windows Update install call failed: $($_.Exception.Message)"
+    }
+
+    $resultCode = [int]$installResult.ResultCode
+    $resultName = $resultCodeNames[$resultCode]
+    if (-not $resultName) { $resultName = "Unknown($resultCode)" }
+    Write-Output "  Install operation result: $resultName ($resultCode)"
+
+    if ($resultCode -ne 2) {
+        $failedTitles = @()
+        for ($idx = 0; $idx -lt $updatesToInstall.Count; $idx++) {
+            $perResult = $installResult.GetUpdateResult($idx)
+            $perCode = [int]$perResult.ResultCode
+            if ($perCode -ne 2) {
+                $hresult = "0x{0:X8}" -f ([int]$perResult.HResult)
+                $title = $updatesToInstall.Item($idx).Title
+                $perName = $resultCodeNames[$perCode]
+                if (-not $perName) { $perName = "Unknown($perCode)" }
+                $failedTitles += "  - $title ($perName, HRESULT $hresult)"
+            }
+        }
+
+        $detail = if ($failedTitles.Count -gt 0) { "`n" + ($failedTitles -join "`n") } else { "" }
+        throw "Windows Update install reported $resultName ($resultCode).$detail"
+    }
+
+    if ($installResult.RebootRequired) {
+        Write-Output ""
+        Write-Warning "A reboot is required to complete the update installation."
     }
 }
 

--- a/scripts/users.ps1
+++ b/scripts/users.ps1
@@ -2,7 +2,7 @@
 param (
     [string]$systemPurpose,
     [string]$systemOwnership,
-    [string]$userPassword,
+    [securestring]$userPassword,
     [string]$dedicatedUserName,
     [string]$personalUserName
 )
@@ -28,6 +28,21 @@ function Get-LocalizedUsersGroupName {
     return $usersGroupFull.Split('\')[-1]
 }
 
+function Invoke-SensitiveUserOperation {
+    param (
+        [Parameter(Mandatory)]
+        [scriptblock]$ScriptBlock
+    )
+
+    $transcriptSuspender = Get-Command -Name Invoke-WithInstallTranscriptSuspended -ErrorAction SilentlyContinue
+    if ($transcriptSuspender) {
+        Invoke-WithInstallTranscriptSuspended -ScriptBlock $ScriptBlock
+        return
+    }
+
+    & $ScriptBlock
+}
+
 function Add-UserToUsersGroup {
     [CmdletBinding(SupportsShouldProcess)]
     param (
@@ -36,7 +51,12 @@ function Add-UserToUsersGroup {
     )
 
     $usersGroup = Get-LocalizedUsersGroupName
-    $members = Get-LocalGroupMember -Group $usersGroup -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+    try {
+        $members = @(Get-LocalGroupMember -Group $usersGroup -ErrorAction Stop | Select-Object -ExpandProperty Name)
+    }
+    catch {
+        throw "Could not read members of local group '$usersGroup': $($_.Exception.Message)"
+    }
 
     if ($members -notcontains "$env:COMPUTERNAME\$UserName") {
         if ($PSCmdlet.ShouldProcess($UserName, "Add to $usersGroup group")) {
@@ -51,16 +71,16 @@ $resolved = Resolve-DeploymentUserName -SystemPurpose $systemPurpose -SystemOwne
 $userName = $resolved.UserName
 $enableAutoLogin = $resolved.EnableAutoLogin
 
-# Create or sync the local user account
 if ($userName) {
-    Test-LocalUserPassword -Candidate $userPassword -AccountName $userName
-    $securePassword = ConvertTo-SecureString -String $userPassword -AsPlainText -Force
+    Test-LocalUserPassword -SecurePassword $userPassword -AccountName $userName
     $existingUser = Get-LocalUser -Name $userName -ErrorAction SilentlyContinue
 
     if (-not $existingUser) {
         Write-Output "Creating local user: $userName"
         try {
-            New-LocalUser -Name $userName -Password $securePassword -FullName $userName -Description "User created by deployment script" -ErrorAction Stop
+            Invoke-SensitiveUserOperation -ScriptBlock {
+                New-LocalUser -Name $userName -Password $userPassword -FullName $userName -Description "User created by deployment script" -ErrorAction Stop
+            }
             Add-UserToUsersGroup -UserName $userName
             Write-Output "  User created."
         }
@@ -71,7 +91,9 @@ if ($userName) {
     else {
         Write-Output "User '$userName' already exists; syncing password and group membership."
         try {
-            Set-LocalUser -Name $userName -Password $securePassword -ErrorAction Stop
+            Invoke-SensitiveUserOperation -ScriptBlock {
+                Set-LocalUser -Name $userName -Password $userPassword -ErrorAction Stop
+            }
             Write-Output "  Password synced with deployment input."
         }
         catch {
@@ -92,12 +114,15 @@ $regPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
 if ($userName -and $enableAutoLogin) {
     Write-Output "Configuring auto-login for: $userName"
     try {
-        if ([string]::IsNullOrWhiteSpace($userPassword)) {
+        if (-not $userPassword) {
             throw "A password is required for auto-login."
         }
 
         Set-ItemProperty -Path $regPath -Name "DefaultUserName" -Value $userName -Force -ErrorAction Stop
-        Set-ItemProperty -Path $regPath -Name "DefaultPassword" -Value $userPassword -Force -ErrorAction Stop
+        Invoke-SensitiveUserOperation -ScriptBlock {
+            $plainPassword = ConvertFrom-SecureStringToPlainText -SecureString $userPassword
+            Set-ItemProperty -Path $regPath -Name "DefaultPassword" -Value $plainPassword -Force -ErrorAction Stop
+        }
         Set-ItemProperty -Path $regPath -Name "AutoAdminLogon" -Value 1 -Force -ErrorAction Stop
         Write-Output "  Auto-login configured."
     }
@@ -108,13 +133,8 @@ if ($userName -and $enableAutoLogin) {
 
 # Set maximum password age to unlimited
 Write-Output "Setting password policy (max age unlimited)..."
-try {
-    Invoke-NativeCommand -FilePath "net.exe" `
-        -Arguments @("accounts", "/maxpwage:unlimited") `
-        -FailureMessage "Failed to set password policy" | Out-Null
-}
-catch {
-    Write-Warning $_.Exception.Message
-}
+Invoke-NativeCommand -FilePath "net.exe" `
+    -Arguments @("accounts", "/maxpwage:unlimited") `
+    -FailureMessage "Failed to set password policy" | Out-Null
 
 Write-Output "User settings configured."

--- a/scripts/users.ps1
+++ b/scripts/users.ps1
@@ -28,21 +28,6 @@ function Get-LocalizedUsersGroupName {
     return $usersGroupFull.Split('\')[-1]
 }
 
-function Invoke-SensitiveUserOperation {
-    param (
-        [Parameter(Mandatory)]
-        [scriptblock]$ScriptBlock
-    )
-
-    $transcriptSuspender = Get-Command -Name Invoke-WithInstallTranscriptSuspended -ErrorAction SilentlyContinue
-    if ($transcriptSuspender) {
-        Invoke-WithInstallTranscriptSuspended -ScriptBlock $ScriptBlock
-        return
-    }
-
-    & $ScriptBlock
-}
-
 function Add-UserToUsersGroup {
     [CmdletBinding(SupportsShouldProcess)]
     param (
@@ -78,7 +63,7 @@ if ($userName) {
     if (-not $existingUser) {
         Write-Output "Creating local user: $userName"
         try {
-            Invoke-SensitiveUserOperation -ScriptBlock {
+            Invoke-WithTranscriptSuspended -ScriptBlock {
                 New-LocalUser -Name $userName -Password $userPassword -FullName $userName -Description "User created by deployment script" -ErrorAction Stop
             }
             Add-UserToUsersGroup -UserName $userName
@@ -91,7 +76,7 @@ if ($userName) {
     else {
         Write-Output "User '$userName' already exists; syncing password and group membership."
         try {
-            Invoke-SensitiveUserOperation -ScriptBlock {
+            Invoke-WithTranscriptSuspended -ScriptBlock {
                 Set-LocalUser -Name $userName -Password $userPassword -ErrorAction Stop
             }
             Write-Output "  Password synced with deployment input."
@@ -119,7 +104,7 @@ if ($userName -and $enableAutoLogin) {
         }
 
         Set-ItemProperty -Path $regPath -Name "DefaultUserName" -Value $userName -Force -ErrorAction Stop
-        Invoke-SensitiveUserOperation -ScriptBlock {
+        Invoke-WithTranscriptSuspended -ScriptBlock {
             $plainPassword = ConvertFrom-SecureStringToPlainText -SecureString $userPassword
             Set-ItemProperty -Path $regPath -Name "DefaultPassword" -Value $plainPassword -Force -ErrorAction Stop
         }

--- a/scripts/users.ps1
+++ b/scripts/users.ps1
@@ -11,39 +11,16 @@ param (
 
 Write-Output "Configuring user settings..."
 
-function Test-LocalUserPassword {
+function ConvertTo-FriendlyPasswordError {
     param (
         [Parameter(Mandatory)]
-        [string]$Candidate,
-
-        [Parameter(Mandatory)]
-        [string]$AccountName
+        $ErrorRecord
     )
 
-    if ([string]::IsNullOrWhiteSpace($Candidate)) {
-        throw "A password is required when creating '$AccountName'."
+    if ($ErrorRecord.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.InvalidPasswordException") {
+        return "Password was rejected by the local Windows password policy. Use at least 8 characters, 3 character groups, and do not include the username."
     }
-
-    if ($Candidate.Length -lt 8) {
-        throw "The password for '$AccountName' must be at least 8 characters."
-    }
-
-    $characterClasses = 0
-    if ($Candidate -cmatch "[A-Z]") { $characterClasses++ }
-    if ($Candidate -cmatch "[a-z]") { $characterClasses++ }
-    if ($Candidate -match "\d") { $characterClasses++ }
-    if ($Candidate -match "[^a-zA-Z\d]") { $characterClasses++ }
-
-    if ($characterClasses -lt 3) {
-        throw "The password for '$AccountName' must contain characters from at least 3 of these groups: uppercase, lowercase, numbers, symbols."
-    }
-
-    $userNameParts = @($AccountName -split "[\s._-]+" | Where-Object { $_.Length -ge 3 })
-    foreach ($userNamePart in $userNameParts) {
-        if ($Candidate.IndexOf($userNamePart, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
-            throw "The password for '$AccountName' must not contain username part '$userNamePart'."
-        }
-    }
+    return $ErrorRecord.Exception.Message
 }
 
 function Get-LocalizedUsersGroupName {
@@ -69,59 +46,43 @@ function Add-UserToUsersGroup {
     }
 }
 
-# Determine username based on ownership and purpose
-if ($systemOwnership -eq "dedicated" -and $dedicatedUserName) {
-    # Dedicated system with custom user
-    $userName = $dedicatedUserName
-    $enableAutoLogin = $true
-}
-elseif ($systemOwnership -eq "personal" -and $personalUserName) {
-    # Personal system with custom user (no auto-login)
-    $userName = $personalUserName
-    $enableAutoLogin = $false
-}
-elseif ($systemOwnership -eq "shared") {
-    # Shared system with purpose-based user
-    $userName = switch ($systemPurpose) {
-        'editorial' { "Redactie Gebruiker" }
-        'tv' { "Studio Gebruiker" }
-        'radio' { "Studio Gebruiker" }
-        default { "" }
-    }
-    $enableAutoLogin = ($systemPurpose -ne "plain")
-}
-else {
-    $userName = ""
-    $enableAutoLogin = $false
-}
+$resolved = Resolve-DeploymentUserName -SystemPurpose $systemPurpose -SystemOwnership $systemOwnership `
+    -DedicatedUserName $dedicatedUserName -PersonalUserName $personalUserName
+$userName = $resolved.UserName
+$enableAutoLogin = $resolved.EnableAutoLogin
 
-# Add user if userName is specified
+# Create or sync the local user account
 if ($userName) {
-    if (-not (Get-LocalUser -Name $userName -ErrorAction SilentlyContinue)) {
+    Test-LocalUserPassword -Candidate $userPassword -AccountName $userName
+    $securePassword = ConvertTo-SecureString -String $userPassword -AsPlainText -Force
+    $existingUser = Get-LocalUser -Name $userName -ErrorAction SilentlyContinue
+
+    if (-not $existingUser) {
         Write-Output "Creating local user: $userName"
         try {
-            Test-LocalUserPassword -Candidate $userPassword -AccountName $userName
-            $securePassword = ConvertTo-SecureString -String $userPassword -AsPlainText -Force
             New-LocalUser -Name $userName -Password $securePassword -FullName $userName -Description "User created by deployment script" -ErrorAction Stop
             Add-UserToUsersGroup -UserName $userName
             Write-Output "  User created."
         }
         catch {
-            $errorMessage = $_.Exception.Message
-            if ($_.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.InvalidPasswordException") {
-                $errorMessage = "Password was rejected by the local Windows password policy. Use at least 8 characters, 3 character groups, and do not include the username."
-            }
-            throw "Failed to create user '$userName': $errorMessage"
+            throw "Failed to create user '$userName': $(ConvertTo-FriendlyPasswordError -ErrorRecord $_)"
         }
     }
     else {
-        Write-Output "User '$userName' already exists."
-        # Ensure user is in Users group (may be missing if created before fix)
+        Write-Output "User '$userName' already exists; syncing password and group membership."
+        try {
+            Set-LocalUser -Name $userName -Password $securePassword -ErrorAction Stop
+            Write-Output "  Password synced with deployment input."
+        }
+        catch {
+            throw "Failed to sync password for '$userName': $(ConvertTo-FriendlyPasswordError -ErrorRecord $_)"
+        }
+
         try {
             Add-UserToUsersGroup -UserName $userName
         }
         catch {
-            Write-Warning "Failed to add to Users group: $_"
+            throw "Failed to add '$userName' to Users group: $($_.Exception.Message)"
         }
     }
 }


### PR DESCRIPTION
## Fixes

| # | Issue | Fix |
|---|---|---|
| 1 | `power.ps1` got no params; NIC power-management never fired for radio/tv/dedicated | Now covered by AST-derived map (see below) |
| 2 | Existing-user re-runs left Winlogon `DefaultPassword` mismatched | `users.ps1` calls `Set-LocalUser -Password` on the existing-user branch; password is also validated at the prompt via a new `Read-DeploymentPassword` helper with a re-prompt loop |
| 3 | `dwservice.ps1` ignored installer exit code; timeout was a warning | Inspect exit code; throw on non-zero; throw on timeout; installer cleanup in `finally` |
| 4 | `apps.ps1` always printed "Installation complete." even on failures | Per-app failures aggregated; throw at end with the list of failed apps |
| 5 | `updates.ps1` printed `ResultCode` but never checked it | Inspect WUA `OperationResultCode` and per-update `HResult`; throw on result codes 3/4/5; throw on download failure or partial download |
| 6 | AppLocker reported "complete" with `AppIDSvc` stopped or empty ruleset | Fail-hard on service missing / `sc config` / `sc start` / 30s startup timeout; verify reads back rule counts and `EnforcementMode` |

## Structural change - AST-derived `$scriptRequirements`

#1 happened because the hand-maintained `$scriptRequirements` hashtable in `install.ps1` drifted from `power.ps1`'s actual `param()` block. While auditing I found `debloat.ps1` had the same drift in the other direction (map listed params the script no longer declared), tolerated only because scripts without `[CmdletBinding()]` silently route unknown splat args into `$args`. Adding `[CmdletBinding()]` to debloat would break the whole install with no lint warning.

The map is now derived at runtime by parsing each script's `param()` block via `[System.Management.Automation.Language.Parser]::ParseFile` (new `Get-ScriptParameterNames` helper in `_common.ps1`). A reverse-drift cross-check also parses `install.ps1`'s own param block and aborts if any child script declares a parameter `install.ps1` cannot supply. Both drift directions are now structurally impossible.

## Input-time password enforcement (related to #2)

Triggered by the operator screenshot where the install failed at `users.ps1` *after* eleven other scripts had already run. The validation now runs at the prompt:

- ZIP is downloaded before prompts so `_common.ps1` can be dot-sourced (also fails fast on network outages).
- Username prompts come before the password prompt so the username-substring rule can be enforced.
- `Read-DeploymentPassword` re-prompts on every policy violation; no install steps run with a known-bad password.
- A password supplied via `-userPassword` is validated once and fails fast on rejection.

## Test plan

- [ ] Fresh install on each ownership/purpose combination (shared+radio/tv/editorial/plain, personal+editorial, dedicated+plain with and without auto-login user).
- [ ] `-OnlyRun users` on a system where the local user already exists; verify Winlogon auto-login uses the newly-supplied password.
- [ ] `-OnlyRun power` on a radio/tv/dedicated box; verify NIC power management via `Get-NetAdapterPowerManagement`.
- [ ] `-OnlyRun applocker` with AppIDSvc Disabled; verify the script throws clearly instead of reporting success.
- [ ] Type a weak password at the prompt; verify the re-prompt loop fires.
- [ ] Pass `-userPassword "short"` via CLI; verify install aborts before any script runs.