### PR TITLE
feat(browser): restrict sign-in and install Chrome on personal devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The Microsoft Store app is removed for all ownerships via the debloat phase (`Mi
 | Thunderbird     | x     |    |           |       |
 | VLC             | x     | x  | x         |       |
 
+Personal systems additionally receive Google Chrome regardless of purpose.
+
 Applications are installed via **winget**, except Spotify and MS Office which use direct downloads. Spotify has winget limitations in admin context; Office uses the Office Deployment Tool with a custom config (`config/office.xml`) for Dutch language and excluded apps. On LTSC systems (which lack Microsoft Store), winget is automatically installed with all required dependencies from the official GitHub releases.
 
 ### Shared Systems
@@ -135,6 +137,9 @@ All systems have Windows sounds disabled.
 ## Policy Framework
 
 Policies are applied via LGPO.exe based on system purpose and ownership. Configuration is defined in `policies/config.json`. See [`policies/README.md`](policies/README.md) for the full policy matrix.
+
+Edge and Chrome sign-in are disabled on shared and dedicated systems. Personal
+systems allow only ZuidWest work/school account addresses.
 
 ## Security Hardening
 

--- a/policies/README.md
+++ b/policies/README.md
@@ -21,7 +21,7 @@ policies/
 │   ├── security/                # Autorun, shutdown, NTLM, Defender
 │   └── windows-update/          # Auto-update configuration
 └── user/                        # User-level policies (HKCU, non-admin only)
-    ├── browser/                 # Edge: profile, privacy, autofill, UI, devtools, extensions
+    ├── browser/                 # Edge/Chrome browser policies
     ├── personalization/         # Wallpaper settings
     └── security/                # CMD, Registry, PowerShell, Run, Task Manager, Control Panel, Network
 ```
@@ -96,15 +96,19 @@ The table below is generated from `config.json` by `scripts/ci/generate-policy-m
 | system | windows-update | Disable Auto Reboot | Prevent automatic reboot after updates (dedicated systems have auto-login) |   |   | x |
 | user | browser | Chrome Autofill | Disable Chrome password manager, autofill, passkeys, payments, and imports | x |   |   |
 | user | browser | Chrome Developer Tools | Disable Chrome Developer Tools (F12) | x |   |   |
+| user | browser | Chrome Disable Sign In | Disable Chrome sign-in on shared and dedicated systems | x |   | x |
 | user | browser | Chrome Extensions | Block all Chrome extension installations | x | x | x |
 | user | browser | Chrome Privacy | Chrome privacy, safe browsing, and telemetry defaults | x | x | x |
 | user | browser | Chrome Profile | Chrome ephemeral profiles, no history, no sync | x |   |   |
+| user | browser | Chrome Sign In | Allow only ZuidWest Google accounts for Chrome sign-in on personal systems |   | x |   |
 | user | browser | Chrome UI | Block Chrome notifications/popups, set ZuidWest homepage, and remove promotional UI | x | x | x |
 | user | browser | Edge Autofill | Disable Edge autofill and data import | x |   |   |
 | user | browser | Edge Developer Tools | Disable Edge Developer Tools (F12) | x |   |   |
+| user | browser | Edge Disable Sign In | Disable Edge sign-in on shared and dedicated systems | x |   | x |
 | user | browser | Edge Extensions | Block all Edge extension installations | x |   |   |
 | user | browser | Edge Privacy | Edge tracking prevention and security | x | x | x |
 | user | browser | Edge Profile | Edge ephemeral profiles, no history, no sync | x |   |   |
+| user | browser | Edge Sign In | Allow only ZuidWest work/school accounts for Edge sign-in on personal systems |   | x |   |
 | user | browser | Edge UI | Disable Edge bloatware UI elements and set homepage to zuidwestupdate.nl | x | x | x |
 | user | personalization | Set Wallpaper Black | Set solid black wallpaper for dedicated systems |   |   | x |
 | user | personalization | Set Wallpaper Branded | Set branded ZuidWest wallpaper for shared and personal systems | x | x |   |

--- a/policies/config.json
+++ b/policies/config.json
@@ -91,6 +91,16 @@
       "ownership": ["shared"],
       "description": "Edge ephemeral profiles, no history, no sync"
     },
+    "user/browser/edge-sign-in.txt": {
+      "purposes": ["all"],
+      "ownership": ["personal"],
+      "description": "Allow only ZuidWest work/school accounts for Edge sign-in on personal systems"
+    },
+    "user/browser/edge-disable-sign-in.txt": {
+      "purposes": ["all"],
+      "ownership": ["shared", "dedicated"],
+      "description": "Disable Edge sign-in on shared and dedicated systems"
+    },
     "user/browser/edge-privacy.txt": {
       "purposes": ["all"],
       "ownership": ["all"],
@@ -155,6 +165,16 @@
       "purposes": ["all"],
       "ownership": ["shared"],
       "description": "Chrome ephemeral profiles, no history, no sync"
+    },
+    "user/browser/chrome-sign-in.txt": {
+      "purposes": ["all"],
+      "ownership": ["personal"],
+      "description": "Allow only ZuidWest Google accounts for Chrome sign-in on personal systems"
+    },
+    "user/browser/chrome-disable-sign-in.txt": {
+      "purposes": ["all"],
+      "ownership": ["shared", "dedicated"],
+      "description": "Disable Chrome sign-in on shared and dedicated systems"
     },
     "user/browser/chrome-privacy.txt": {
       "purposes": ["all"],

--- a/policies/user/browser/README.md
+++ b/policies/user/browser/README.md
@@ -1,6 +1,6 @@
 # Browser Policies
 
-Microsoft Edge and Google Chrome: ephemeral profiles for shared systems, strict privacy, no autofill, clean UI, no extensions.
+Microsoft Edge and Google Chrome: ephemeral profiles for shared systems, strict privacy, no autofill, clean UI, no extensions. Browser sign-in is disabled except on personal systems, where only ZuidWest work/school accounts are allowed.
 
 ## Policies
 
@@ -12,10 +12,29 @@ Shared systems only. Profiles are deleted on exit.
 |---------|-------|--------|
 | `ForceEphemeralProfiles` | 1 | Profiles deleted when browser session ends |
 | `SyncDisabled` | 1 | Disables data synchronization |
-| `BrowserSignin` | 0 | Disables browser sign-in completely |
 | `HideFirstRunExperience` | 1 | Hides first-run experience and splash screen |
 | `BrowserAddProfileEnabled` | 0 | Prevents users from creating new profiles |
 | `BrowserGuestModeEnabled` | 0 | Disables guest profile browsing mode |
+
+### `edge-sign-in.txt`
+
+Personal systems only. Edge sign-in is allowed only for ZuidWest work/school
+account UPNs in the `zuidwestupdate.nl`, `zuidwesttv.nl`, and `zuidwestfm.nl`
+domains.
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `BrowserSignin` | 1 | Allows browser sign-in for accounts matching the allowed pattern |
+| `RestrictSigninToPattern` | `(?i)^[^@]+@(zuidwestupdate\.nl\|zuidwesttv\.nl\|zuidwestfm\.nl)$` | Blocks personal/non-ZuidWest accounts from Edge sign-in |
+| `MSAWebSiteSSOUsingThisProfileAllowed` | 0 | Blocks personal Microsoft account SSO in non-MSA profiles |
+
+### `edge-disable-sign-in.txt`
+
+Shared and dedicated systems only.
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `BrowserSignin` | 0 | Disables Edge browser sign-in completely |
 
 ### `edge-privacy.txt`
 
@@ -101,10 +120,28 @@ Shared systems only. Profiles are deleted on exit and browsing history is not sa
 |---------|-------|--------|
 | `ForceEphemeralProfiles` | 1 | Profiles deleted when browser session ends |
 | `SyncDisabled` | 1 | Disables data synchronization |
-| `BrowserSignin` | 0 | Disables browser sign-in completely |
 | `BrowserGuestModeEnabled` | 0 | Disables guest profile browsing mode |
 | `ProfilePickerOnStartupAvailability` | 1 | Disables the profile picker at startup |
 | `SavingBrowserHistoryDisabled` | 1 | Prevents saving browsing history |
+
+### `chrome-sign-in.txt`
+
+Personal systems only. Chrome sign-in is allowed only for ZuidWest Google
+account addresses in the `zuidwestupdate.nl`, `zuidwesttv.nl`, and `zuidwestfm.nl`
+domains.
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `BrowserSignin` | 1 | Allows Chrome sign-in for accounts matching the allowed pattern |
+| `RestrictSigninToPattern` | `(?i)^[^@]+@(zuidwestupdate\.nl\|zuidwesttv\.nl\|zuidwestfm\.nl)$` | Blocks personal/non-ZuidWest Google accounts from Chrome sign-in |
+
+### `chrome-disable-sign-in.txt`
+
+Shared and dedicated systems only.
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `BrowserSignin` | 0 | Disables Chrome browser sign-in completely |
 
 ### `chrome-privacy.txt`
 

--- a/policies/user/browser/chrome-disable-sign-in.txt
+++ b/policies/user/browser/chrome-disable-sign-in.txt
@@ -1,0 +1,4 @@
+User
+Software\Policies\Google\Chrome
+BrowserSignin
+DWORD:0

--- a/policies/user/browser/chrome-profile.txt
+++ b/policies/user/browser/chrome-profile.txt
@@ -10,11 +10,6 @@ DWORD:1
 
 User
 Software\Policies\Google\Chrome
-BrowserSignin
-DWORD:0
-
-User
-Software\Policies\Google\Chrome
 BrowserGuestModeEnabled
 DWORD:0
 
@@ -27,4 +22,3 @@ User
 Software\Policies\Google\Chrome
 SavingBrowserHistoryDisabled
 DWORD:1
-

--- a/policies/user/browser/chrome-sign-in.txt
+++ b/policies/user/browser/chrome-sign-in.txt
@@ -1,0 +1,9 @@
+User
+Software\Policies\Google\Chrome
+BrowserSignin
+DWORD:1
+
+User
+Software\Policies\Google\Chrome
+RestrictSigninToPattern
+SZ:(?i)^[^@]+@(zuidwestupdate\.nl|zuidwesttv\.nl|zuidwestfm\.nl)$

--- a/policies/user/browser/edge-disable-sign-in.txt
+++ b/policies/user/browser/edge-disable-sign-in.txt
@@ -1,0 +1,4 @@
+User
+Software\Policies\Microsoft\Edge
+BrowserSignin
+DWORD:0

--- a/policies/user/browser/edge-profile.txt
+++ b/policies/user/browser/edge-profile.txt
@@ -10,11 +10,6 @@ DWORD:1
 
 User
 Software\Policies\Microsoft\Edge
-BrowserSignin
-DWORD:0
-
-User
-Software\Policies\Microsoft\Edge
 HideFirstRunExperience
 DWORD:1
 

--- a/policies/user/browser/edge-sign-in.txt
+++ b/policies/user/browser/edge-sign-in.txt
@@ -1,0 +1,14 @@
+User
+Software\Policies\Microsoft\Edge
+BrowserSignin
+DWORD:1
+
+User
+Software\Policies\Microsoft\Edge
+RestrictSigninToPattern
+SZ:(?i)^[^@]+@(zuidwestupdate\.nl|zuidwesttv\.nl|zuidwestfm\.nl)$
+
+User
+Software\Policies\Microsoft\Edge
+MSAWebSiteSSOUsingThisProfileAllowed
+DWORD:0

--- a/scripts/apps.ps1
+++ b/scripts/apps.ps1
@@ -7,8 +7,9 @@ param (
 . (Join-Path $PSScriptRoot "_common.ps1")
 
 <#
-This script installs applications based on the specified purpose.
+This script installs applications based on the specified purpose and ownership.
 'systemPurpose' should be "radio", "tv", "editorial", or "plain".
+'systemOwnership' should be "shared", "personal", or "dedicated".
 #>
 
 function New-Shortcut {
@@ -37,6 +38,7 @@ function New-Shortcut {
 # Winget package IDs (apps installed via winget)
 $appDefinitions = @{
     "audacity"      = "Audacity.Audacity"
+    "chrome"        = "Google.Chrome"
     "creativecloud" = "Adobe.CreativeCloud"
     "libreoffice"   = "TheDocumentFoundation.LibreOffice"
     "msteams"       = "Microsoft.Teams"
@@ -56,6 +58,17 @@ $appsByPurpose = @{
     "plain"     = @()
 }
 
+# Applications by ownership. Empty entries are intentional: every supported
+# ownership is explicit, even when it has no ownership-specific apps.
+$appsByOwnership = @{
+    "personal"  = @("chrome")
+    "shared"    = @()
+    "dedicated" = @()
+}
+
+$validPurposes = @($appsByPurpose.Keys | Sort-Object)
+$validOwnership = @($appsByOwnership.Keys | Sort-Object)
+
 # Validate parameters
 if (-not $systemPurpose) {
     throw "'systemPurpose' parameter must be provided."
@@ -63,14 +76,26 @@ if (-not $systemPurpose) {
 
 $systemPurpose = $systemPurpose.ToLower()
 if (-not $appsByPurpose.ContainsKey($systemPurpose)) {
-    throw "Invalid 'systemPurpose': $systemPurpose. Valid values: radio, tv, editorial, plain"
+    throw "Invalid 'systemPurpose': $systemPurpose. Valid values: $($validPurposes -join ', ')"
 }
 
-# Get apps for this purpose
-$apps = $appsByPurpose[$systemPurpose]
+if (-not $systemOwnership) {
+    throw "'systemOwnership' parameter must be provided."
+}
+
+$systemOwnership = $systemOwnership.ToLower()
+if (-not $appsByOwnership.ContainsKey($systemOwnership)) {
+    throw "Invalid 'systemOwnership': $systemOwnership. Valid values: $($validOwnership -join ', ')"
+}
+
+# Merge purpose and ownership app selections; Unique avoids duplicate installs
+# if an app is later selected by both dimensions.
+$apps = @($appsByPurpose[$systemPurpose])
+$apps += $appsByOwnership[$systemOwnership]
+$apps = @($apps | Select-Object -Unique)
 
 if ($apps.Count -eq 0) {
-    Write-Output "No apps to install for '$systemPurpose'."
+    Write-Output "No apps to install for purpose '$systemPurpose' and ownership '$systemOwnership'."
     return
 }
 
@@ -135,7 +160,7 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     throw "Winget not available. A reboot may be required."
 }
 
-Write-Output "Installing apps for '$systemPurpose'..."
+Write-Output "Installing apps for purpose '$systemPurpose' and ownership '$systemOwnership'..."
 
 $failedApps = [System.Collections.Generic.List[string]]::new()
 
@@ -157,7 +182,7 @@ foreach ($app in $apps) {
     $packageId = $appDefinitions[$app]
 
     if (-not $packageId) {
-        throw "App '$app' is selected for purpose '$systemPurpose' but is not defined in the app catalog. This is a baseline bug; add it to either the winget definitions or the special-installer list."
+        throw "App '$app' is selected for purpose '$systemPurpose' and ownership '$systemOwnership' but is not defined in the app catalog. This is a baseline bug; add it to either the winget definitions or the special-installer list."
     }
 
     Write-Output "Installing $app ($packageId)..."


### PR DESCRIPTION
## Summary
- restrict Edge and Chrome sign-in to personal ownership only
- allow only ZuidWest work/school account UPNs on personal systems
- disable browser sign-in on shared and dedicated systems
- install Google Chrome automatically on personal devices

## Validation
- git diff --check
- jq empty policies/config.json
- npx --yes ajv-cli validate -s policies/config.schema.json -d policies/config.json --all-errors
- ./scripts/ci/generate-policy-matrix.sh check
- PowerShell parse, formatter, and ScriptAnalyzer checks for scripts/apps.ps1
- LGPO block shape check
- sign-in regex smoke test