### PR TITLE
Add scheduled policy auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Available scripts: `debloat`, `securitybaseline`, `applocker`, `apps`, `dwservic
 A full install also registers an auto-update Scheduled Task (`\ZuidWest\PolicyAutoUpdate`) so policy changes pushed to `main` propagate to every deployed machine without a manual re-run.
 
 - **Triggers:** system startup (15 min jitter), any user logon (5 min jitter), hourly thereafter (60 min jitter).
-- **What it does:** reads the public commits.atom feed at `https://github.com/oszuidwest/windows11-baseline/commits/main.atom` (not the REST API, so no 60 req/h/IP quota) to learn the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override.
+- **What it does:** reads the public commits.atom feed at `https://github.com/oszuidwest/windows11-baseline/commits/main.atom` (not the REST API, so no 60 req/h/IP quota) to learn the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override. If github.com rate-limits a fleet behind one NAT, the updater persists the backoff window from the response headers and skips checks until it passes.
 - **Runtime layout:** all ZuidWest-managed deployment/runtime files live under `C:\ProgramData\ZuidWest`.
   - `C:\ProgramData\ZuidWest\deploy` - current full-install deploy cache
-  - `C:\ProgramData\ZuidWest\policy-update\state.json` - purpose, ownership, repo coordinates, last applied SHA
+  - `C:\ProgramData\ZuidWest\policy-update\state.json` - purpose, ownership, repo coordinates, enabled flag, last applied SHA
   - `C:\ProgramData\ZuidWest\policy-update\update.ps1` - the auto-updater payload (self-refreshes from `scripts/lib/policy-auto-updater.ps1` on each successful apply)
   - `C:\ProgramData\ZuidWest\Logs\policy-auto-update.log` - rotated at 5 MB
 
-To refresh the task or change which scripts get re-applied, re-run `install.ps1 -OnlyRun policyupdate`. To disable, delete the Scheduled Task: `Unregister-ScheduledTask -TaskPath '\ZuidWest\' -TaskName 'PolicyAutoUpdate' -Confirm:$false`.
+To refresh the task or change which scripts get re-applied, re-run `install.ps1 -OnlyRun policyupdate`. To pause auto-update on a machine without deleting the task, set `enabled` to `false` in `C:\ProgramData\ZuidWest\policy-update\state.json`; set it back to `true` to resume. To disable fully, delete the Scheduled Task: `Unregister-ScheduledTask -TaskPath '\ZuidWest\' -TaskName 'PolicyAutoUpdate' -Confirm:$false`.
 
 ## Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Available scripts: `debloat`, `securitybaseline`, `applocker`, `apps`, `dwservic
 A full install also registers an auto-update Scheduled Task (`\ZuidWest\PolicyAutoUpdate`) so policy changes pushed to `main` propagate to every deployed machine without a manual re-run.
 
 - **Triggers:** system startup, any user logon, hourly thereafter.
-- **What it does:** asks the GitHub API for the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override (so it never touches `C:\Windows\deploy`).
+- **What it does:** reads the public commits.atom feed at `https://github.com/oszuidwest/windows11-baseline/commits/main.atom` (not the REST API, so no 60 req/h/IP quota) to learn the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override (so it never touches `C:\Windows\deploy`).
 - **State and logs:**
   - `C:\ProgramData\ZuidWest\policy-update\state.json` - purpose, ownership, repo coordinates, last applied SHA
   - `C:\ProgramData\ZuidWest\policy-update\update.ps1` - the auto-updater payload (self-refreshes from `scripts/lib/policy-auto-updater.ps1` on each successful apply)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,20 @@ Start-Process powershell.exe -ArgumentList "-NoProfile -ExecutionPolicy Bypass -
 Start-Process powershell.exe -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command `"& { iwr 'https://raw.githubusercontent.com/oszuidwest/windows11-baseline/main/install.ps1' -OutFile `$env:TEMP\install.ps1; & `$env:TEMP\install.ps1 -OnlyRun 'policies','hardening' }`"" -Verb RunAs
 ```
 
-Available scripts: `debloat`, `securitybaseline`, `applocker`, `apps`, `dwservice`, `hardening`, `policies`, `power`, `sounds`, `time`, `updates`, `users`, `workgroupname`
+Available scripts: `debloat`, `securitybaseline`, `applocker`, `apps`, `dwservice`, `hardening`, `policies`, `policyupdate`, `power`, `sounds`, `time`, `updates`, `users`, `workgroupname`
+
+### Auto-Update for Policies
+
+A full install also registers an auto-update Scheduled Task (`\ZuidWest\PolicyAutoUpdate`) so policy changes pushed to `main` propagate to every deployed machine without a manual re-run.
+
+- **Triggers:** system startup, any user logon, hourly thereafter.
+- **What it does:** asks the GitHub API for the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override (so it never touches `C:\Windows\deploy`).
+- **State and logs:**
+  - `C:\ProgramData\ZuidWest\policy-update\state.json` - purpose, ownership, repo coordinates, last applied SHA
+  - `C:\ProgramData\ZuidWest\policy-update\update.ps1` - the auto-updater payload (self-refreshes from `scripts/lib/policy-auto-updater.ps1` on each successful apply)
+  - `C:\ProgramData\ZuidWest\Logs\policy-auto-update.log` - rotated at 5 MB
+
+To refresh the task or change which scripts get re-applied, re-run `install.ps1 -OnlyRun policyupdate`. To disable, delete the Scheduled Task: `Unregister-ScheduledTask -TaskPath '\ZuidWest\' -TaskName 'PolicyAutoUpdate' -Confirm:$false`.
 
 ## Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Available scripts: `debloat`, `securitybaseline`, `applocker`, `apps`, `dwservic
 
 A full install also registers an auto-update Scheduled Task (`\ZuidWest\PolicyAutoUpdate`) so policy changes pushed to `main` propagate to every deployed machine without a manual re-run.
 
-- **Triggers:** system startup, any user logon, hourly thereafter.
-- **What it does:** reads the public commits.atom feed at `https://github.com/oszuidwest/windows11-baseline/commits/main.atom` (not the REST API, so no 60 req/h/IP quota) to learn the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override (so it never touches `C:\Windows\deploy`).
-- **State and logs:**
+- **Triggers:** system startup (15 min jitter), any user logon (5 min jitter), hourly thereafter (60 min jitter).
+- **What it does:** reads the public commits.atom feed at `https://github.com/oszuidwest/windows11-baseline/commits/main.atom` (not the REST API, so no 60 req/h/IP quota) to learn the current `main` commit SHA. If it matches the last applied SHA, exits silently. If different, downloads the archive for that SHA into `C:\ProgramData\ZuidWest\policy-update\staging`, then re-runs `policies` and `applocker` against that staged copy via the `$env:WINDOWS11_BASELINE_DEPLOY_PATH` override.
+- **Runtime layout:** all ZuidWest-managed deployment/runtime files live under `C:\ProgramData\ZuidWest`.
+  - `C:\ProgramData\ZuidWest\deploy` - current full-install deploy cache
   - `C:\ProgramData\ZuidWest\policy-update\state.json` - purpose, ownership, repo coordinates, last applied SHA
   - `C:\ProgramData\ZuidWest\policy-update\update.ps1` - the auto-updater payload (self-refreshes from `scripts/lib/policy-auto-updater.ps1` on each successful apply)
   - `C:\ProgramData\ZuidWest\Logs\policy-auto-update.log` - rotated at 5 MB

--- a/bin/hashes.json
+++ b/bin/hashes.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Runtime hashes for Microsoft binaries shipped in this directory. Bumping a binary requires bumping the matching SHA-256 here in the same commit. scripts/_common.ps1 :: Assert-BundledBinary enforces this at runtime; mismatches throw before the binary is invoked. Hashes must also match bin/README.md and the Authenticode signature must remain a valid Microsoft signature.",
+  "algorithm": "SHA256",
+  "binaries": {
+    "LGPO.exe": "0c97f29543418b30340c4ff5d930d31e6196dd59c2cc74b6b890fa7b90c910c7",
+    "AppLockerPolicyTool.exe": "163a7d3454437a43401f292ac4a48aa5c044ab54565aef4d76b39046bdf4a26d"
+  }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -9,9 +9,14 @@ param(
     [string[]]$OnlyRun
 )
 
+$ErrorActionPreference = "Stop"
+
 $script:ZuidWestRoot = Join-Path $env:ProgramData "ZuidWest"
 $script:InstallLogRoot = Join-Path $script:ZuidWestRoot "Logs"
 $script:DeployRoot = Join-Path $script:ZuidWestRoot "deploy"
+$script:RepoOwner = "oszuidwest"
+$script:RepoName = "windows11-baseline"
+$script:RepoBranch = "main"
 
 # Function to check for admin rights
 function Test-Admin {
@@ -73,6 +78,40 @@ function Wait-BeforeExit {
     Read-Host -Prompt $Prompt | Out-Null
 }
 
+function Resolve-GitHubBranchSha {
+    param (
+        [Parameter(Mandatory)]
+        [string]$Owner,
+
+        [Parameter(Mandatory)]
+        [string]$Repo,
+
+        [Parameter(Mandatory)]
+        [string]$Branch
+    )
+
+    $url = "https://github.com/$Owner/$Repo/commits/$Branch.atom"
+    $headers = @{
+        "User-Agent" = "windows11-baseline-installer"
+        "Accept"     = "application/atom+xml"
+    }
+
+    $previousProgressPreference = $ProgressPreference
+    try {
+        $ProgressPreference = "SilentlyContinue"
+        $response = Invoke-WebRequest -Uri $url -Headers $headers -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop
+    }
+    finally {
+        $ProgressPreference = $previousProgressPreference
+    }
+
+    if ($response.Content -match 'tag:github\.com,2008:Grit::Commit/([a-fA-F0-9]{40})') {
+        return $Matches[1].ToLower()
+    }
+
+    throw "Could not resolve latest commit SHA from $url"
+}
+
 function Write-FatalInstallError {
     param (
         [Parameter(Mandatory)]
@@ -84,7 +123,7 @@ function Write-FatalInstallError {
     )
 
     Write-Output ""
-    Write-Error $Message
+    Write-Error -Message $Message -ErrorAction Continue
     if ($ErrorRecord) {
         Write-Output "Details: $ErrorRecord"
     }
@@ -129,9 +168,18 @@ Write-Output ""
 
 # Download before prompting so we can source _common.ps1 and validate the password input.
 $deployDir = $script:DeployRoot
-$zipUrl = "https://github.com/oszuidwest/windows11-baseline/archive/refs/heads/main.zip"
+$installedSha = $null
+try {
+    Write-Output "Resolving $($script:RepoOwner)/$($script:RepoName)@$($script:RepoBranch)..."
+    $installedSha = Resolve-GitHubBranchSha -Owner $script:RepoOwner -Repo $script:RepoName -Branch $script:RepoBranch
+    Write-Output "Resolved commit SHA: $installedSha"
+}
+catch {
+    Write-FatalInstallError -Message "Failed to resolve the current deployment commit." -ErrorRecord $_
+}
+
+$zipUrl = "https://github.com/$($script:RepoOwner)/$($script:RepoName)/archive/$installedSha.zip"
 $zipFilePath = Join-Path $deployDir "main.zip"
-$sourceDir = Join-Path $deployDir "windows11-baseline-main"
 
 if (Test-Path $deployDir) {
     Remove-Item -Path $deployDir -Recurse -Force
@@ -153,15 +201,16 @@ catch {
 
 Remove-Item -Path $zipFilePath -Force
 
-if (Test-Path $sourceDir) {
-    Write-Output "Moving contents from $sourceDir to $deployDir..."
-    Get-ChildItem -Path $sourceDir | Move-Item -Destination $deployDir -Force
-    Remove-Item -Path $sourceDir -Recurse -Force
-    Write-Output "Contents moved and $sourceDir removed."
+$extractedDirs = @(Get-ChildItem -Path $deployDir -Directory)
+if ($extractedDirs.Count -ne 1) {
+    Write-FatalInstallError -Message "Expected exactly one extracted repository directory under $deployDir, found $($extractedDirs.Count)."
 }
-else {
-    Write-FatalInstallError -Message "$sourceDir does not exist. Exiting..."
-}
+
+$sourceDir = $extractedDirs[0].FullName
+Write-Output "Moving contents from $sourceDir to $deployDir..."
+Get-ChildItem -Path $sourceDir -Force | Move-Item -Destination $deployDir -Force
+Remove-Item -Path $sourceDir -Recurse -Force
+Write-Output "Contents moved and $sourceDir removed."
 
 $commonPath = Join-Path $deployDir "scripts\_common.ps1"
 if (-not (Test-Path $commonPath)) {
@@ -182,7 +231,9 @@ $installerInputNames = @(
     "userPassword",
     "dwAgentCode",
     "dedicatedUserName",
-    "personalUserName"
+    "personalUserName",
+    "installedSha",
+    "seedInstalledSha"
 )
 
 # Explicit installer input requirements. This is the source of truth for prompting;
@@ -194,7 +245,7 @@ $scriptRequirements = @{
     'dwservice'        = @('dwAgentCode')
     'hardening'        = @()
     'policies'         = @('systemPurpose', 'systemOwnership')
-    'policyupdate'     = @('systemPurpose', 'systemOwnership')
+    'policyupdate'     = @('systemPurpose', 'systemOwnership', 'installedSha', 'seedInstalledSha')
     'power'            = @('systemPurpose', 'systemOwnership')
     'securitybaseline' = @()
     'sounds'           = @()
@@ -381,6 +432,8 @@ $allParams = @{
     dwAgentCode       = $dwAgentCode
     dedicatedUserName = $dedicatedUserName
     personalUserName  = $personalUserName
+    installedSha      = $installedSha
+    seedInstalledSha  = (-not $OnlyRun) -or (('policyupdate' -in $OnlyRun) -and ('policies' -in $OnlyRun) -and ('applocker' -in $OnlyRun))
 }
 
 foreach ($scriptFile in $scriptFiles) {

--- a/install.ps1
+++ b/install.ps1
@@ -9,6 +9,10 @@ param(
     [string[]]$OnlyRun
 )
 
+$script:ZuidWestRoot = Join-Path $env:ProgramData "ZuidWest"
+$script:InstallLogRoot = Join-Path $script:ZuidWestRoot "Logs"
+$script:DeployRoot = Join-Path $script:ZuidWestRoot "deploy"
+
 # Function to check for admin rights
 function Test-Admin {
     $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -21,7 +25,7 @@ $script:InstallLogPath = $null
 function Initialize-InstallLog {
     $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
     $logDirectories = @(
-        (Join-Path $env:ProgramData "ZuidWest\Logs"),
+        $script:InstallLogRoot,
         $env:TEMP
     )
 
@@ -124,10 +128,10 @@ Write-Output "This script will configure a Windows 11 system with the specified 
 Write-Output ""
 
 # Download before prompting so we can source _common.ps1 and validate the password input.
-$deployDir = "C:\Windows\deploy"
+$deployDir = $script:DeployRoot
 $zipUrl = "https://github.com/oszuidwest/windows11-baseline/archive/refs/heads/main.zip"
-$zipFilePath = "$deployDir\main.zip"
-$sourceDir = "$deployDir\windows11-baseline-main"
+$zipFilePath = Join-Path $deployDir "main.zip"
+$sourceDir = Join-Path $deployDir "windows11-baseline-main"
 
 if (Test-Path $deployDir) {
     Remove-Item -Path $deployDir -Recurse -Force

--- a/install.ps1
+++ b/install.ps1
@@ -1,11 +1,5 @@
-#===============================================================
-# Windows 11 Baseline for Streekomroep ZuidWest
-#===============================================================
-
 param(
-    # Valid script names are derived from scripts/*.ps1 after download; see the validation block
-    # near the discovery code below. ValidateSet would lock us to a hardcoded list and drift from
-    # the filesystem.
+    # Validated after download against the discovered scripts to avoid a stale ValidateSet.
     [string[]]$OnlyRun
 )
 
@@ -18,7 +12,6 @@ $script:RepoOwner = "oszuidwest"
 $script:RepoName = "windows11-baseline"
 $script:RepoBranch = "main"
 
-# Function to check for admin rights
 function Test-Admin {
     $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
     $adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
@@ -152,12 +145,10 @@ trap {
     Write-FatalInstallError -Message "Unexpected fatal error." -ErrorRecord $_
 }
 
-# Ensure the script runs with admin rights
 if (-not (Test-Admin)) {
     Write-FatalInstallError -Message "This script must be run as an administrator. Exiting..."
 }
 
-# Welcome message
 Write-Output ""
 Write-Output "=========================================="
 Write-Output " Windows 11 Baseline - Streekomroep ZuidWest"
@@ -166,7 +157,7 @@ Write-Output ""
 Write-Output "This script will configure a Windows 11 system with the specified settings."
 Write-Output ""
 
-# Download before prompting so we can source _common.ps1 and validate the password input.
+# Download first so _common.ps1 can validate later prompts.
 $deployDir = $script:DeployRoot
 $installedSha = $null
 try {
@@ -220,7 +211,6 @@ if (-not (Test-Path $commonPath)) {
 
 Write-Output ""
 
-# Valid options
 $validPurposes = @("radio", "tv", "editorial", "plain")
 $validOwnership = @("shared", "personal", "dedicated")
 $installerInputNames = @(
@@ -236,8 +226,7 @@ $installerInputNames = @(
     "seedInstalledSha"
 )
 
-# Explicit installer input requirements. This is the source of truth for prompting;
-# the AST check below only verifies this map against each script's param() block.
+# Source of truth for prompts; AST parsing only checks this map for drift.
 $scriptRequirements = @{
     'applocker'        = @('systemOwnership')
     'apps'             = @('systemPurpose', 'systemOwnership')
@@ -255,7 +244,7 @@ $scriptRequirements = @{
     'workgroupname'    = @('computerName', 'workgroupName')
 }
 
-# Discover scripts so -OnlyRun validation and execution still follow the deployed filesystem.
+# Keep -OnlyRun validation and execution tied to the deployed filesystem.
 $scriptsDir = Join-Path $deployDir "scripts"
 if (-not (Test-Path $scriptsDir)) {
     Write-FatalInstallError -Message "Script directory does not exist: $scriptsDir"
@@ -266,7 +255,7 @@ $scriptFiles = @(Get-ChildItem -Path $scriptsDir -Filter *.ps1 |
         Sort-Object Name)
 $discoveredScriptParams = @{}
 $scriptFiles | ForEach-Object {
-    # Public script names strip a leading ordering underscore: _securitybaseline.ps1 -> securitybaseline.
+    # _securitybaseline.ps1 is exposed as securitybaseline.
     $scriptName = $_.BaseName -replace '^_', ''
     $discoveredScriptParams[$scriptName] = Get-ScriptParameterNames -Path $_.FullName
 }
@@ -284,7 +273,7 @@ if ($staleMappings.Count -gt 0) {
     Write-FatalInstallError -Message "Installer requirement map contains script(s) that no longer exist: $($staleMappings -join ', ')"
 }
 
-# Reverse-drift check: a script param that install.ps1 cannot collect would otherwise splat $null silently.
+# Prevent silently splatting $null for params the installer cannot collect.
 $detectedParamCount = @($discoveredScriptParams.Values | ForEach-Object { $_ }).Count
 $mappedParamCount = @($scriptRequirements.Values | ForEach-Object { $_ }).Count
 $canValidateParamDrift = -not ($mappedParamCount -gt 0 -and $detectedParamCount -eq 0)
@@ -325,7 +314,6 @@ else {
     }
 }
 
-# Validate -OnlyRun against the discovered script names.
 if ($OnlyRun) {
     $validScriptNames = @($scriptRequirements.Keys | Sort-Object)
     $unknown = @($OnlyRun | Where-Object { $_ -notin $validScriptNames })
@@ -334,16 +322,13 @@ if ($OnlyRun) {
     }
 }
 
-# Determine which parameters are required based on -OnlyRun
 if ($OnlyRun) {
     $requiredParams = @($OnlyRun | ForEach-Object { $scriptRequirements[$_] } | Select-Object -Unique)
 }
 else {
-    # Full installation: collect requirements for all scripts
     $requiredParams = @($scriptRequirements.Values | ForEach-Object { $_ } | Select-Object -Unique)
 }
 
-# Get and validate system purpose if required.
 if ('systemPurpose' -in $requiredParams) {
     do {
         Write-Output "System purpose options: $($validPurposes -join ', ')"
@@ -356,7 +341,6 @@ if ('systemPurpose' -in $requiredParams) {
     Write-Output ""
 }
 
-# Get and validate system ownership if required.
 if ('systemOwnership' -in $requiredParams) {
     do {
         Write-Output "System ownership options: $($validOwnership -join ', ')"
@@ -369,17 +353,14 @@ if ('systemOwnership' -in $requiredParams) {
     Write-Output ""
 }
 
-# Get computer name if required.
 if ('computerName' -in $requiredParams) {
     $computerName = Read-Host -Prompt "Enter the computer name"
 }
 
-# Get workgroup name if required.
 if ('workgroupName' -in $requiredParams) {
     $workgroupName = Read-Host -Prompt "Enter the workgroup name"
 }
 
-# For dedicated systems, ask if a user with auto-login should be created
 if ('dedicatedUserName' -in $requiredParams -and $systemOwnership -eq "dedicated") {
     Write-Output ""
     $createUser = (Read-Host -Prompt "Create a user with auto-login? (y/n)").ToLower().Trim()
@@ -388,7 +369,6 @@ if ('dedicatedUserName' -in $requiredParams -and $systemOwnership -eq "dedicated
     }
 }
 
-# For personal systems, ask for username (required)
 if ('personalUserName' -in $requiredParams -and $systemOwnership -eq "personal") {
     Write-Output ""
     do {
@@ -410,7 +390,6 @@ if ('userPassword' -in $requiredParams) {
     }
 }
 
-# Get DWService agent code if required.
 if ('dwAgentCode' -in $requiredParams) {
     Write-Output ""
     Write-Output "DWService agent code (from dwservice.net, leave empty to skip)"
@@ -418,10 +397,6 @@ if ('dwAgentCode' -in $requiredParams) {
 }
 
 Write-Output ""
-
-#===============================================================
-# Execute all scripts in the scripts directory
-#===============================================================
 
 $allParams = @{
     systemPurpose     = $systemPurpose
@@ -439,7 +414,6 @@ $allParams = @{
 foreach ($scriptFile in $scriptFiles) {
     $scriptName = $scriptFile.BaseName -replace '^_', ''
 
-    # Skip scripts not in -OnlyRun list (if specified)
     if ($OnlyRun -and $scriptName -notin $OnlyRun) {
         Write-Output "Skipping: $($scriptFile.Name) (not in -OnlyRun list)"
         continue

--- a/install.ps1
+++ b/install.ps1
@@ -190,6 +190,7 @@ $scriptRequirements = @{
     'dwservice'        = @('dwAgentCode')
     'hardening'        = @()
     'policies'         = @('systemPurpose', 'systemOwnership')
+    'policyupdate'     = @('systemPurpose', 'systemOwnership')
     'power'            = @('systemPurpose', 'systemOwnership')
     'securitybaseline' = @()
     'sounds'           = @()

--- a/policies/applocker/personal.xml
+++ b/policies/applocker/personal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    AppLocker policy for personal systems: no enforcement.
+
+    Applied via scripts/applocker.ps1 so that re-deploying a previously
+    shared or dedicated machine as personal explicitly clears any
+    enforced rule collections (EnforcementMode="NotConfigured" with no
+    rules). Without this, the AppLocker rules from the previous
+    template would remain in LGPO until manually cleared.
+-->
+<AppLockerPolicy Version="1">
+    <RuleCollection Type="Exe" EnforcementMode="NotConfigured"/>
+    <RuleCollection Type="Appx" EnforcementMode="NotConfigured"/>
+</AppLockerPolicy>

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -247,6 +247,20 @@ function Assert-BundledBinary {
     if (-not $actual.Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
         throw "SHA-256 mismatch for '$binaryName' (expected $expected, got $actual). Refusing to invoke."
     }
+
+    if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) {
+        throw "Get-AuthenticodeSignature is not available. Refusing to invoke '$binaryName' without validating its Microsoft signature."
+    }
+
+    $signature = Get-AuthenticodeSignature -FilePath $BinaryPath
+    if ($signature.Status -ne "Valid") {
+        throw "Authenticode signature for '$binaryName' is not valid (status: $($signature.Status)). Refusing to invoke."
+    }
+
+    $subject = $signature.SignerCertificate.Subject
+    if ($subject -notmatch "Microsoft Corporation") {
+        throw "Authenticode signature for '$binaryName' was not issued to Microsoft Corporation (subject: $subject). Refusing to invoke."
+    }
 }
 
 function Get-ScriptParameterNames {
@@ -388,7 +402,7 @@ function Read-DeploymentPassword {
     }
 }
 
-# WUA orcSucceeded == 2. See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wsusss/0a8c5b85-2123-4ed9-a6cd-7d23e23e3786
+# WUA orcSucceeded == 2. See https://learn.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-operationresultcode
 $script:WuaSucceededCode = 2
 
 function Test-WuaSucceeded {

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -104,6 +104,85 @@ function Invoke-Download {
     }
 }
 
+function Save-DeploymentStateAtomic {
+    <#
+    .SYNOPSIS
+        Atomically write a JSON state file, keeping a single-generation backup.
+
+    .DESCRIPTION
+        Writes the JSON serialisation of $State to "$Path.tmp", then uses
+        [System.IO.File]::Replace (which on NTFS maps to ReplaceFileW) to
+        atomically swap it into place and move the previous contents to
+        "$Path.bak". For first-time writes (no existing file at $Path) it
+        falls back to a plain Move-Item.
+
+        The contract: power loss or crash during the write leaves either the
+        old contents intact at $Path, or the new contents at $Path with the
+        old contents at "$Path.bak". The state file is never partially
+        truncated. Pair with Read-DeploymentState for the matching .bak
+        fallback on read.
+
+    .PARAMETER Path
+        Absolute path to the state file (e.g. state.json).
+
+    .PARAMETER State
+        Any object that ConvertTo-Json can serialise.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        $State
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Path, "Atomic state write")) {
+        return
+    }
+
+    $tmpPath = "$Path.tmp"
+    $bakPath = "$Path.bak"
+    $State | ConvertTo-Json -Depth 6 | Set-Content -Path $tmpPath -Encoding UTF8 -Force
+    if (Test-Path $Path) {
+        [System.IO.File]::Replace($tmpPath, $Path, $bakPath)
+    }
+    else {
+        Move-Item -Path $tmpPath -Destination $Path -Force
+    }
+}
+
+function Read-DeploymentState {
+    <#
+    .SYNOPSIS
+        Read a JSON state file, falling back to the .bak generation on corruption.
+
+    .DESCRIPTION
+        Reads $Path. If the JSON parse fails (truncation, partial write before
+        Save-DeploymentStateAtomic landed) and "$Path.bak" exists, it logs a
+        warning and returns the parsed backup instead. If both are corrupt,
+        the original parse exception is rethrown.
+    #>
+    [OutputType([object])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    try {
+        return Get-Content -Path $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        $bakPath = "$Path.bak"
+        if (Test-Path $bakPath) {
+            Write-Warning "State file at $Path appears corrupt; falling back to $bakPath"
+            return Get-Content -Path $bakPath -Raw | ConvertFrom-Json
+        }
+        throw
+    }
+}
+
 function Assert-BundledBinary {
     <#
     .SYNOPSIS

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -124,26 +124,11 @@ function Invoke-Download {
 function Save-DeploymentStateAtomic {
     <#
     .SYNOPSIS
-        Atomically write a JSON state file, keeping a single-generation backup.
+        Atomically write JSON state with one .bak generation.
 
     .DESCRIPTION
-        Writes the JSON serialisation of $State to "$Path.tmp", then uses
-        [System.IO.File]::Replace (which on NTFS maps to ReplaceFileW) to
-        atomically swap it into place and move the previous contents to
-        "$Path.bak". For first-time writes (no existing file at $Path) it
-        falls back to a plain Move-Item.
-
-        The contract: power loss or crash during the write leaves either the
-        old contents intact at $Path, or the new contents at $Path with the
-        old contents at "$Path.bak". The state file is never partially
-        truncated. Pair with Read-DeploymentState for the matching .bak
-        fallback on read.
-
-    .PARAMETER Path
-        Absolute path to the state file (e.g. state.json).
-
-    .PARAMETER State
-        Any object that ConvertTo-Json can serialise.
+        Writes to "$Path.tmp", swaps it into place with File.Replace when
+        possible, and keeps "$Path.bak" for read fallback.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param (
@@ -172,13 +157,10 @@ function Save-DeploymentStateAtomic {
 function Read-DeploymentState {
     <#
     .SYNOPSIS
-        Read a JSON state file, falling back to the .bak generation on corruption.
+        Read JSON state, falling back to .bak if the main file is corrupt.
 
     .DESCRIPTION
-        Reads $Path. If the JSON parse fails (truncation, partial write before
-        Save-DeploymentStateAtomic landed) and "$Path.bak" exists, it logs a
-        warning and returns the parsed backup instead. If both are corrupt,
-        the original parse exception is rethrown.
+        If both generations fail, the original parse exception is rethrown.
     #>
     [OutputType([object])]
     [CmdletBinding()]
@@ -203,19 +185,11 @@ function Read-DeploymentState {
 function Assert-BundledBinary {
     <#
     .SYNOPSIS
-        Verify a binary in bin/ matches the SHA-256 declared in bin/hashes.json.
+        Verify a bundled binary before invocation.
 
     .DESCRIPTION
-        Reads the hashes manifest under the current deploy path (Get-DeployPath
-        honours $env:WINDOWS11_BASELINE_DEPLOY_PATH, so this works when the
-        auto-updater is operating against a staged copy too). Computes the
-        SHA-256 of the binary and throws if it does not match. Calling this
-        before every native invocation of a bundled Microsoft EXE prevents a
-        compromised or accidentally swapped repo copy from being executed.
-
-    .PARAMETER BinaryPath
-        Absolute path to the binary to verify. The lookup key into hashes.json
-        is the file name (e.g. "LGPO.exe").
+        Checks SHA-256 from bin/hashes.json and a valid Microsoft Authenticode
+        signature. Get-DeployPath supports staged auto-update copies.
     #>
     [CmdletBinding()]
     param (
@@ -485,9 +459,7 @@ function Assert-WuaOperationSucceeded {
     throw "Windows Update $($Phase.ToLower()) reported $name ($code).$detail"
 }
 
-# install.ps1 publishes the active transcript path to $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH;
-# child scripts (invoked via &) read it to suspend/resume the parent transcript around plaintext
-# secrets (e.g. registry writes that would otherwise be captured).
+# Child scripts suspend the parent transcript around plaintext secrets.
 function Suspend-InstallTranscript {
     if (-not $env:WINDOWS11_BASELINE_TRANSCRIPT_PATH) {
         return $false

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -104,6 +104,55 @@ function Invoke-Download {
     }
 }
 
+function Assert-BundledBinary {
+    <#
+    .SYNOPSIS
+        Verify a binary in bin/ matches the SHA-256 declared in bin/hashes.json.
+
+    .DESCRIPTION
+        Reads the hashes manifest under the current deploy path (Get-DeployPath
+        honours $env:WINDOWS11_BASELINE_DEPLOY_PATH, so this works when the
+        auto-updater is operating against a staged copy too). Computes the
+        SHA-256 of the binary and throws if it does not match. Calling this
+        before every native invocation of a bundled Microsoft EXE prevents a
+        compromised or accidentally swapped repo copy from being executed.
+
+    .PARAMETER BinaryPath
+        Absolute path to the binary to verify. The lookup key into hashes.json
+        is the file name (e.g. "LGPO.exe").
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$BinaryPath
+    )
+
+    if (-not (Test-Path $BinaryPath)) {
+        throw "Bundled binary not found at $BinaryPath"
+    }
+
+    $manifestPath = Join-DeployPath "bin", "hashes.json"
+    if (-not (Test-Path $manifestPath)) {
+        throw "Bundled binary manifest not found at $manifestPath. Refusing to run an unverified binary."
+    }
+
+    $manifest = Get-Content -Path $manifestPath -Raw | ConvertFrom-Json
+    if (-not $manifest.binaries) {
+        throw "Bundled binary manifest at $manifestPath is missing a 'binaries' object."
+    }
+
+    $binaryName = Split-Path -Path $BinaryPath -Leaf
+    $expected = $manifest.binaries.$binaryName
+    if (-not $expected) {
+        throw "No expected SHA-256 declared for '$binaryName' in $manifestPath. Add it in the same commit as the binary bump."
+    }
+
+    $actual = (Get-FileHash -Path $BinaryPath -Algorithm SHA256).Hash
+    if (-not $actual.Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "SHA-256 mismatch for '$binaryName' (expected $expected, got $actual). Refusing to invoke."
+    }
+}
+
 function Get-ScriptParameterNames {
     [OutputType([string[]])]
     param (

--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -3,12 +3,29 @@
     Shared helpers for Windows 11 baseline deployment scripts.
 #>
 
+function Get-ZuidWestRoot {
+    return (Join-Path $env:ProgramData "ZuidWest")
+}
+
+function Join-ZuidWestPath {
+    param (
+        [Parameter(Mandatory, Position = 0)]
+        [string[]]$ChildPath
+    )
+
+    $path = Get-ZuidWestRoot
+    foreach ($child in $ChildPath) {
+        $path = Join-Path $path $child
+    }
+    return $path
+}
+
 function Get-DeployPath {
     if ($env:WINDOWS11_BASELINE_DEPLOY_PATH) {
         return $env:WINDOWS11_BASELINE_DEPLOY_PATH
     }
 
-    return "C:\Windows\deploy"
+    return (Join-ZuidWestPath "deploy")
 }
 
 function Join-DeployPath {

--- a/scripts/_debloat.ps1
+++ b/scripts/_debloat.ps1
@@ -11,7 +11,6 @@ function Remove-BloatwareApp {
         [string]$AppName
     )
 
-    # Remove installed packages for all users
     Get-AppxPackage -AllUsers -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "*$AppName*" } |
         ForEach-Object {
@@ -21,7 +20,7 @@ function Remove-BloatwareApp {
             }
         }
 
-    # Remove provisioned packages (prevents reinstallation)
+    # Remove provisioning so packages do not return for new users.
     Get-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue |
         Where-Object { $_.DisplayName -like "*$AppName*" -or $_.PackageName -like "*$AppName*" } |
         ForEach-Object {

--- a/scripts/_securitybaseline.ps1
+++ b/scripts/_securitybaseline.ps1
@@ -38,9 +38,7 @@ Write-Output "=== Microsoft Windows 11 24H2 Security Baseline ==="
 Write-Output ""
 
 try {
-    if (-not (Test-Path $lgpoPath)) {
-        throw "LGPO.exe not found at $lgpoPath"
-    }
+    Assert-BundledBinary -BinaryPath $lgpoPath
 
     $currentBuild = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").CurrentBuildNumber
     if ($currentBuild -ne "26100") {

--- a/scripts/applocker.ps1
+++ b/scripts/applocker.ps1
@@ -2,6 +2,8 @@ param (
     [string]$systemOwnership
 )
 
+$ErrorActionPreference = "Stop"
+
 . (Join-Path $PSScriptRoot "_common.ps1")
 
 <#

--- a/scripts/applocker.ps1
+++ b/scripts/applocker.ps1
@@ -20,7 +20,10 @@ param (
     - Blocks Microsoft Copilot application only
     - Microsoft Store appx is still removed via the debloat phase
 
-    Personal systems: No AppLocker policies applied.
+    Personal systems (policies/applocker/personal.xml):
+    - No enforcement. An empty policy is still applied so that a machine
+      previously deployed as shared or dedicated has its existing AppLocker
+      rules cleared rather than left in place.
 
     Prerequisites:
     - Windows Enterprise or Education edition (LTSC qualifies)
@@ -37,20 +40,26 @@ $appLockerTemplateDir = Join-DeployPath "policies\applocker"
 Write-Output "=== AppLocker Configuration ==="
 Write-Output ""
 
-# Select template based on ownership
+# Select template based on ownership. "personal" applies an empty policy so a
+# re-deploy from shared/dedicated to personal explicitly clears prior rules.
 switch ($systemOwnership) {
     "shared" {
         $templateName = "shared.xml"
         $policyDescription = "Store + Copilot + StoreInstaller.exe"
+        $isResetTemplate = $false
     }
     "dedicated" {
         $templateName = "dedicated.xml"
         $policyDescription = "Copilot only"
+        $isResetTemplate = $false
+    }
+    "personal" {
+        $templateName = "personal.xml"
+        $policyDescription = "no enforcement (clears prior rules)"
+        $isResetTemplate = $true
     }
     default {
-        Write-Output "Skipping AppLocker configuration (only applies to shared/dedicated systems)"
-        Write-Output "Current ownership: $systemOwnership"
-        return
+        throw "Unsupported systemOwnership '$systemOwnership' (expected shared, dedicated, or personal)."
     }
 }
 
@@ -129,17 +138,40 @@ catch {
     throw "Could not read back local AppLocker policy after apply: $($_.Exception.Message)"
 }
 
-if (-not $policy -or -not $policy.RuleCollections) {
-    throw "Local AppLocker policy is empty after apply; enforcement would silently no-op."
+$exeRules = if ($policy -and $policy.RuleCollections) {
+    $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Exe" }
 }
-
-$exeRules = $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Exe" }
-$appxRules = $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Appx" }
+$appxRules = if ($policy -and $policy.RuleCollections) {
+    $policy.RuleCollections | Where-Object { $_.RuleCollectionType -eq "Appx" }
+}
 $exeRuleCount = if ($exeRules) { ($exeRules | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum } else { 0 }
 $appxRuleCount = if ($appxRules) { ($appxRules | ForEach-Object { $_.Count } | Measure-Object -Sum).Sum } else { 0 }
 
 Write-Output "  Executable rules: $exeRuleCount"
 Write-Output "  Packaged app rules: $appxRuleCount"
+
+if ($isResetTemplate) {
+    # personal.xml: rule collections must be empty AND not enforced.
+    if ($exeRuleCount -ne 0 -or $appxRuleCount -ne 0) {
+        throw "AppLocker reset applied but rules remain (Exe=$exeRuleCount, Appx=$appxRuleCount)."
+    }
+    $managedCollections = @($policy.RuleCollections | Where-Object { $_.RuleCollectionType -in @("Exe", "Appx") })
+    $stillEnforced = @($managedCollections | Where-Object { $_.EnforcementMode -eq "Enabled" })
+    if ($stillEnforced.Count -gt 0) {
+        $modes = ($stillEnforced | ForEach-Object { "$($_.RuleCollectionType)=$($_.EnforcementMode)" }) -join ", "
+        throw "AppLocker reset applied but rule collections still enforce: $modes."
+    }
+
+    Write-Output ""
+    Write-Output "=== AppLocker reset complete ==="
+    Write-Output ""
+    Write-Output "Existing AppLocker rules cleared; no enforcement on this system."
+    return
+}
+
+if (-not $policy -or -not $policy.RuleCollections) {
+    throw "Local AppLocker policy is empty after apply; enforcement would silently no-op."
+}
 
 if ($exeRuleCount -eq 0 -or $appxRuleCount -eq 0) {
     throw "AppLocker policy applied but rule counts are empty (Exe=$exeRuleCount, Appx=$appxRuleCount); enforcement would silently no-op."

--- a/scripts/applocker.ps1
+++ b/scripts/applocker.ps1
@@ -70,9 +70,7 @@ Write-Output "Template: $templateName"
 Write-Output "Blocks: $policyDescription"
 Write-Output ""
 
-if (-not (Test-Path $appLockerToolPath)) {
-    throw "AppLockerPolicyTool.exe not found at $appLockerToolPath"
-}
+Assert-BundledBinary -BinaryPath $appLockerToolPath
 
 if (-not (Test-Path $templatePath)) {
     throw "AppLocker template not found at $templatePath"

--- a/scripts/applocker.ps1
+++ b/scripts/applocker.ps1
@@ -35,15 +35,13 @@ $ErrorActionPreference = "Stop"
     The ownership type: "shared", "personal", or "dedicated"
 #>
 
-# Paths
 $appLockerToolPath = Join-DeployPath "bin\AppLockerPolicyTool.exe"
 $appLockerTemplateDir = Join-DeployPath "policies\applocker"
 
 Write-Output "=== AppLocker Configuration ==="
 Write-Output ""
 
-# Select template based on ownership. "personal" applies an empty policy so a
-# re-deploy from shared/dedicated to personal explicitly clears prior rules.
+# personal.xml clears rules left by earlier shared/dedicated deployments.
 switch ($systemOwnership) {
     "shared" {
         $templateName = "shared.xml"
@@ -78,7 +76,6 @@ if (-not (Test-Path $templatePath)) {
     throw "AppLocker template not found at $templatePath"
 }
 
-# Step 1: Enable and start the Application Identity service
 Write-Output "Enabling Application Identity service (AppIdSvc)..."
 
 $service = Get-Service -Name "AppIDSvc" -ErrorAction SilentlyContinue
@@ -113,7 +110,6 @@ else {
 
 Write-Output ""
 
-# Step 2: Apply AppLocker policy template
 Write-Output "Applying AppLocker policy from $templateName..."
 
 try {
@@ -128,7 +124,6 @@ catch {
 
 Write-Output ""
 
-# Step 3: Verify policy was applied
 Write-Output "Verifying AppLocker policy..."
 
 try {
@@ -151,7 +146,7 @@ Write-Output "  Executable rules: $exeRuleCount"
 Write-Output "  Packaged app rules: $appxRuleCount"
 
 if ($isResetTemplate) {
-    # personal.xml: rule collections must be empty AND not enforced.
+    # Reset template must leave managed collections empty and not enforced.
     if ($exeRuleCount -ne 0 -or $appxRuleCount -ne 0) {
         throw "AppLocker reset applied but rules remain (Exe=$exeRuleCount, Appx=$appxRuleCount)."
     }

--- a/scripts/apps.ps1
+++ b/scripts/apps.ps1
@@ -1,4 +1,3 @@
-# Define script parameters
 param (
     [string]$systemPurpose,
     [string]$systemOwnership
@@ -78,7 +77,7 @@ function Install-WingetDependencyPackage {
     }
 }
 
-# Winget package IDs (apps installed via winget)
+# App catalog.
 $appDefinitions = @{
     "audacity"      = "Audacity.Audacity"
     "chrome"        = "Google.Chrome"
@@ -90,10 +89,8 @@ $appDefinitions = @{
     "vlc"           = "VideoLAN.VLC"
 }
 
-# Apps requiring special installation (not via winget)
 $specialApps = @("spotify", "office")
 
-# Applications by purpose
 $appsByPurpose = @{
     "radio"     = @("audacity", "libreoffice", "spotify", "thunderbird", "vlc")
     "tv"        = @("creativecloud", "libreoffice", "vlc")
@@ -101,8 +98,7 @@ $appsByPurpose = @{
     "plain"     = @()
 }
 
-# Applications by ownership. Empty entries are intentional: every supported
-# ownership is explicit, even when it has no ownership-specific apps.
+# Empty ownership entries are intentional.
 $appsByOwnership = @{
     "personal"  = @("chrome")
     "shared"    = @()
@@ -112,7 +108,6 @@ $appsByOwnership = @{
 $validPurposes = @($appsByPurpose.Keys | Sort-Object)
 $validOwnership = @($appsByOwnership.Keys | Sort-Object)
 
-# Validate parameters
 if (-not $systemPurpose) {
     throw "'systemPurpose' parameter must be provided."
 }
@@ -131,8 +126,7 @@ if (-not $appsByOwnership.ContainsKey($systemOwnership)) {
     throw "Invalid 'systemOwnership': $systemOwnership. Valid values: $($validOwnership -join ', ')"
 }
 
-# Merge purpose and ownership app selections; Unique avoids duplicate installs
-# if an app is later selected by both dimensions.
+# Avoid duplicates if an app is selected by both dimensions.
 $apps = @($appsByPurpose[$systemPurpose])
 $apps += $appsByOwnership[$systemOwnership]
 $apps = @($apps | Select-Object -Unique)
@@ -142,7 +136,7 @@ if ($apps.Count -eq 0) {
     return
 }
 
-# Install winget if not available (required for LTSC which has no Microsoft Store)
+# LTSC has no Microsoft Store, so bootstrap winget when missing.
 if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     Write-Output "Winget not found. Installing for LTSC..."
 
@@ -151,40 +145,34 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     $ProgressPreference = 'SilentlyContinue'
 
     try {
-        # Get latest winget release info from GitHub
         Write-Output "  Fetching latest Winget release..."
         $release = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/winget-cli/releases/latest" -UseBasicParsing
         $msixUrl = ($release.assets | Where-Object { $_.name -match "\.msixbundle$" }).browser_download_url
         $licenseUrl = ($release.assets | Where-Object { $_.name -match "License.*\.xml$" }).browser_download_url
         $depsUrl = ($release.assets | Where-Object { $_.name -eq "DesktopAppInstaller_Dependencies.zip" }).browser_download_url
 
-        # Download dependencies zip (contains VCLibs + WindowsAppRuntime)
         Write-Output "  Downloading dependencies..."
         $depsZip = Join-Path $tempDir "deps.zip"
         $depsDir = Join-Path $tempDir "deps"
         Invoke-Download -Uri $depsUrl -OutFile $depsZip
         Expand-Archive -Path $depsZip -DestinationPath $depsDir -Force
 
-        # Detect architecture and install matching dependencies
         $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" }
         Write-Output "  Installing dependencies for $arch..."
         Get-ChildItem -Path (Join-Path $depsDir $arch) -Filter "*.appx" | Sort-Object Name | ForEach-Object {
             Install-WingetDependencyPackage -Path $_.FullName
         }
 
-        # Download winget msixbundle and license
         Write-Output "  Downloading Winget..."
         $msixPath = Join-Path $tempDir "winget.msixbundle"
         $licensePath = Join-Path $tempDir "license.xml"
         Invoke-Download -Uri $msixUrl -OutFile $msixPath
         Invoke-Download -Uri $licenseUrl -OutFile $licensePath
 
-        # Install winget (current user + provision for all users)
         Write-Output "  Installing Winget..."
         Add-AppxPackage -Path $msixPath -ErrorAction Stop
         Add-AppxProvisionedPackage -Online -PackagePath $msixPath -LicensePath $licensePath -ErrorAction Stop | Out-Null
 
-        # Wait for winget to become available and refresh PATH
         Start-Sleep -Seconds 3
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
@@ -198,7 +186,6 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     }
 }
 
-# Verify winget is now available
 if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     throw "Winget not available. A reboot may be required."
 }
@@ -215,9 +202,7 @@ $failedApps = [System.Collections.Generic.List[string]]::new()
 #   0x8A15010D INSTALL_ALREADY_INSTALLED   (-1978334963) - underlying MSI/EXE installer
 $wingetSuccessExitCodes = @(0, -1978335189, -1978335135, -1978334963)
 
-# Install apps via winget
 foreach ($app in $apps) {
-    # Skip special apps (handled separately)
     if ($specialApps -contains $app) {
         continue
     }
@@ -240,7 +225,7 @@ foreach ($app in $apps) {
     }
 }
 
-# Install Spotify (requires special handling - winget fails in admin context)
+# Winget fails for Spotify in elevated installer context.
 if ($apps -contains "spotify") {
     Write-Output "Installing Spotify (direct download)..."
 
@@ -276,7 +261,6 @@ if ($apps -contains "spotify") {
     }
 }
 
-# Install Microsoft Office (using Office Deployment Tool)
 if ($apps -contains "office") {
     Write-Output "Installing Microsoft Office..."
 
@@ -319,7 +303,6 @@ if ($failedApps.Count -gt 0) {
     throw "App installation failed for: $($failedApps -join '; '). The workstation is not deployment-ready for '$systemPurpose'; re-run with -OnlyRun apps after investigating."
 }
 
-# Create WhatsApp Web shortcut (InPrivate mode) for shared computers
 if ($systemOwnership -eq "shared") {
     Write-Output "Creating WhatsApp Web shortcut (InPrivate mode)..."
 
@@ -333,7 +316,6 @@ if ($systemOwnership -eq "shared") {
     }
     $arguments = "--app=https://web.whatsapp.com --inprivate --mute-audio --window-size=800,600"
 
-    # Download WhatsApp icon
     $iconUrl = "https://web.whatsapp.com/favicon.ico"
     try {
         Invoke-Download -Uri $iconUrl -OutFile $iconPath

--- a/scripts/dwservice.ps1
+++ b/scripts/dwservice.ps1
@@ -20,7 +20,6 @@ param (
     If no agent code is provided, installation is skipped.
 #>
 
-# Skip if no agent code provided
 if (-not $dwAgentCode) {
     Write-Output "Skipping DWService installation (no agent code provided)."
     return
@@ -31,7 +30,6 @@ Write-Output "Installing DWService..."
 $installerPath = Join-DeployPath "dwagent.exe"
 $dwServiceUrl = "https://www.dwservice.net/download/dwagent.exe"
 
-# Download DWService installer
 Write-Output "Downloading DWService agent..."
 try {
     Invoke-Download -Uri $dwServiceUrl -OutFile $installerPath
@@ -41,7 +39,6 @@ catch {
     throw "Failed to download DWService: $($_.Exception.Message)"
 }
 
-# Run the DWService installer with the configured agent code.
 Write-Output "Installing DWService with agent code..."
 $maxMinutes = 5
 try {

--- a/scripts/hardening.ps1
+++ b/scripts/hardening.ps1
@@ -7,7 +7,6 @@ Runs for all system purposes and ownership types.
 
 Write-Output "Applying security hardening..."
 
-# Disable Remote Registry service (attack surface reduction)
 Write-Output "Disabling Remote Registry service..."
 try {
     Stop-Service -Name RemoteRegistry -Force -ErrorAction SilentlyContinue

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -27,6 +27,12 @@
          the staging directory back over its install location, and removes the
          staging directory.
 
+    State writes use Save-StateAtomicLocal (defined inline at startup so it
+    is available before the staged scripts/_common.ps1 is sourced). Reads use
+    Read-StateOrBakLocal, which falls back to "$statePath.bak" if the main
+    file fails to parse. This protects the updater from being permanently
+    bricked by a power loss or crash mid-write.
+
     A single-instance file lock prevents overlapping runs when multiple
     triggers fire close together (e.g. boot + logon).
 
@@ -46,6 +52,41 @@ $logDir = Join-Path $env:ProgramData "ZuidWest\Logs"
 $logPath = Join-Path $logDir "policy-auto-update.log"
 $lockPath = Join-Path $persistentRoot "update.lock"
 $selfPath = $PSCommandPath
+
+# Inline copies of the atomic state helpers. The canonical implementations
+# live in scripts/_common.ps1, but we need them before the staged _common.ps1
+# is sourced (we have to read state.json to know which repo to download from).
+# Re-defining them after dot-sourcing is harmless: the bodies are identical.
+function Save-StateAtomicLocal {
+    param (
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)]$State
+    )
+    $tmpPath = "$Path.tmp"
+    $bakPath = "$Path.bak"
+    $State | ConvertTo-Json -Depth 6 | Set-Content -Path $tmpPath -Encoding UTF8 -Force
+    if (Test-Path $Path) {
+        [System.IO.File]::Replace($tmpPath, $Path, $bakPath)
+    }
+    else {
+        Move-Item -Path $tmpPath -Destination $Path -Force
+    }
+}
+
+function Read-StateOrBakLocal {
+    param ([Parameter(Mandatory)][string]$Path)
+    try {
+        return Get-Content -Path $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        $bakPath = "$Path.bak"
+        if (Test-Path $bakPath) {
+            Write-UpdateLog "State at $Path corrupt; falling back to $bakPath." "WARN"
+            return Get-Content -Path $bakPath -Raw | ConvertFrom-Json
+        }
+        throw
+    }
+}
 
 function Write-UpdateLog {
     param (
@@ -101,7 +142,7 @@ try {
         return
     }
 
-    $state = Get-Content -Path $statePath -Raw | ConvertFrom-Json
+    $state = Read-StateOrBakLocal -Path $statePath
 
     $repoOwner = $state.repoOwner
     $repoName = $state.repoName
@@ -146,7 +187,7 @@ try {
     # Record the check time even when there is nothing to apply.
     $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
     $state.lastCheckAt = $now
-    $state | ConvertTo-Json -Depth 4 | Set-Content -Path $statePath -Encoding UTF8
+    Save-StateAtomicLocal -Path $statePath -State $state
 
     if ($state.lastAppliedSha -eq $remoteSha) {
         Write-UpdateLog "Already at $remoteSha; nothing to do."
@@ -247,7 +288,7 @@ try {
 
     $state.lastAppliedSha = $remoteSha
     $state.lastAppliedAt = $now
-    $state | ConvertTo-Json -Depth 4 | Set-Content -Path $statePath -Encoding UTF8
+    Save-StateAtomicLocal -Path $statePath -State $state
 
     # Refresh the deployed copy of this script so updater fixes shipped via main propagate.
     $newSelf = Join-Path $stagingRoot "scripts\lib\policy-auto-updater.ps1"

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -258,7 +258,7 @@ try {
     $state = Read-StateOrBakLocal -Path $statePath
 
     # Ensure newer schema fields exist even when reading an older state file.
-    foreach ($field in @('lastSelfUpdateSha', 'lastEtag', 'backoffUntil', 'lastCheckAt', 'pollOffsetMinutes')) {
+    foreach ($field in @('lastSelfUpdateSha', 'lastEtag', 'backoffUntil', 'lastCheckAt')) {
         if (-not ($state.PSObject.Properties.Name -contains $field)) {
             $state | Add-Member -NotePropertyName $field -NotePropertyValue $null -Force
         }

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -11,15 +11,21 @@
     that SHA matches the SHAs already applied on this machine.
 
     Rate-limit posture (GitHub unauthenticated cap is 60 req/h/IP):
-      - Conditional requests via If-None-Match. A 304 response does not count
-        against the rate limit, so steady-state polling burns ~0 quota per
-        machine until something actually changes on the branch.
-      - On 403/429 the X-RateLimit-Reset / Retry-After headers are honoured
-        and persisted to state.backoffUntil; subsequent ticks return early
-        until that time has passed.
-      - The scheduled-task trigger anchored by policyupdate.ps1 includes a
-        per-install minute offset so a fleet behind one NAT does not all
-        fire simultaneously.
+      - Conditional requests via If-None-Match always save bandwidth on the
+        steady-state poll. Whether the 304 also avoids spending rate-limit
+        quota is documented as conditional on the request being
+        authenticated, so this implementation does not rely on it for the
+        unauthenticated case; the backoff handler below is the actual
+        defence.
+      - On 403/429 the response headers are honoured per GitHub's REST API
+        best practices: Retry-After takes precedence (it signals the
+        secondary / abuse-detection limit), then X-RateLimit-Reset is used
+        only when X-RateLimit-Remaining is 0, with a 1-minute floor
+        fallback. The resulting wake time is persisted to state.backoffUntil
+        and short-circuits subsequent ticks until it passes.
+      - The scheduled-task trigger anchored by policyupdate.ps1 uses
+        -RandomDelay so each fleet member fires at a different minute
+        within the hour.
 
     On a SHA that differs from either state.lastAppliedSha (policies need
     re-running) or state.lastSelfUpdateSha (the deployed copy of this script
@@ -131,15 +137,43 @@ function Get-BackoffUntilFromHeaders {
         Compute when polling may resume after a 403/429 from the GitHub API.
 
     .DESCRIPTION
-        GitHub signals the primary-rate-limit reset via X-RateLimit-Reset
-        (Unix epoch seconds) and the secondary-rate-limit retry via
-        Retry-After (seconds). Falls back to a 15-minute window if neither
-        header is present. Output is a DateTime in UTC.
+        Implements the resume-time logic from GitHub's REST API best practices
+        guide (https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api):
+
+          1. If Retry-After is set, wait that many seconds (it carries the
+             secondary / abuse-detection limit and takes precedence).
+          2. Otherwise, if X-RateLimit-Remaining is 0, wait until
+             X-RateLimit-Reset (Unix epoch seconds, the primary-limit reset).
+          3. Otherwise fall back to a 1-minute floor; subsequent scheduled
+             ticks effectively give us exponential spacing across the hour.
+
+        Output is a DateTime in UTC.
     #>
     [OutputType([datetime])]
     param ($Headers)
 
-    if ($Headers) {
+    $now = (Get-Date).ToUniversalTime()
+
+    if (-not $Headers) {
+        return $now.AddMinutes(1)
+    }
+
+    # 1. Retry-After wins when set: secondary rate / abuse detection.
+    $retryRaw = $Headers["Retry-After"]
+    if ($retryRaw) {
+        $seconds = 0
+        if ([int]::TryParse([string]$retryRaw, [ref]$seconds) -and $seconds -gt 0) {
+            return $now.AddSeconds($seconds)
+        }
+    }
+
+    # 2. Primary limit exhausted (Remaining == 0): honour X-RateLimit-Reset.
+    $remaining = -1
+    $remainingRaw = $Headers["X-RateLimit-Remaining"]
+    if ($remainingRaw) {
+        [int]::TryParse([string]$remainingRaw, [ref]$remaining) | Out-Null
+    }
+    if ($remaining -eq 0) {
         $resetRaw = $Headers["X-RateLimit-Reset"]
         if ($resetRaw) {
             $epoch = 0
@@ -147,16 +181,10 @@ function Get-BackoffUntilFromHeaders {
                 return [DateTimeOffset]::FromUnixTimeSeconds($epoch).UtcDateTime
             }
         }
-        $retryRaw = $Headers["Retry-After"]
-        if ($retryRaw) {
-            $seconds = 0
-            if ([int]::TryParse([string]$retryRaw, [ref]$seconds) -and $seconds -gt 0) {
-                return (Get-Date).ToUniversalTime().AddSeconds($seconds)
-            }
-        }
     }
 
-    return (Get-Date).ToUniversalTime().AddMinutes(15)
+    # 3. No header hints: GitHub recommends at least one minute before retry.
+    return $now.AddMinutes(1)
 }
 
 function Invoke-GitHubApiCommitCheck {

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -416,8 +416,11 @@ try {
                 )
                 $scriptPath = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
                 if (-not $scriptPath) {
-                    Write-UpdateLog "Script '$scriptName' not found in staging; skipping." "WARN"
-                    continue
+                    # Hard fail. Skipping would let lastAppliedSha advance and
+                    # short-circuit the missing script forever, even though the
+                    # operator explicitly requested it.
+                    Write-UpdateLog "Script '$scriptName' is in scriptsToReapply but not found in staging; aborting (lastAppliedSha not advanced)." "ERROR"
+                    return
                 }
 
                 $detectedParams = Get-ScriptParameterNames -Path $scriptPath

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -6,9 +6,10 @@
 .DESCRIPTION
     Runs as SYSTEM under the "ZuidWest\PolicyAutoUpdate" Scheduled Task.
     Reads its deployment state from C:\ProgramData\ZuidWest\policy-update\state.json
-    (written at install time by scripts/policyupdate.ps1), asks the GitHub API
-    for the HEAD commit SHA of the configured branch, and short-circuits when
-    that SHA matches the SHAs already applied on this machine.
+    (written at install time by scripts/policyupdate.ps1), reads github.com's
+    public commits.atom feed for the configured branch to learn the HEAD
+    commit SHA, and short-circuits when that SHA matches the SHAs already
+    applied on this machine.
 
     Rate-limit posture:
       - The SHA check goes to the public atom feed at
@@ -134,11 +135,15 @@ function Write-UpdateLog {
 function Get-BackoffUntilFromHeaders {
     <#
     .SYNOPSIS
-        Compute when polling may resume after a 403/429 from the GitHub API.
+        Compute when polling may resume after a 403/429 from github.com.
 
     .DESCRIPTION
         Implements the resume-time logic from GitHub's REST API best practices
-        guide (https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api):
+        guide (https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api).
+        Although the auto-updater talks to github.com's commits.atom feed and
+        not to api.github.com, github.com's general rate limiter uses the same
+        Retry-After / X-RateLimit-* header conventions, so the same ordering
+        applies:
 
           1. If Retry-After is set, wait that many seconds (it carries the
              secondary / abuse-detection limit and takes precedence).

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -24,9 +24,9 @@
         1-minute floor fallback. The resulting wake time is persisted to
         state.backoffUntil and short-circuits subsequent ticks until it
         passes.
-      - The scheduled-task trigger anchored by policyupdate.ps1 uses
-        -RandomDelay so each fleet member fires at a different minute
-        within the hour.
+      - The scheduled-task triggers anchored by policyupdate.ps1 use
+        -RandomDelay so startup, logon, and hourly checks do not fire in
+        lockstep across the fleet.
 
     On a SHA that differs from either state.lastAppliedSha (policies need
     re-running) or state.lastSelfUpdateSha (the deployed copy of this script
@@ -38,7 +38,7 @@
          ($env:WINDOWS11_BASELINE_DEPLOY_PATH) at the staging directory so
          the existing sub-scripts (which use Get-DeployPath / Join-DeployPath
          from scripts/_common.ps1) operate on the freshly downloaded copy
-         without touching C:\Windows\deploy.
+         without touching the persistent deploy cache.
       3. If policy is stale: runs each script listed in state.scriptsToReapply
          (default: policies, applocker), passing systemPurpose /
          systemOwnership from the state file. Sub-scripts are invoked
@@ -68,10 +68,11 @@
 
 $ErrorActionPreference = "Stop"
 
-$persistentRoot = Join-Path $env:ProgramData "ZuidWest\policy-update"
+$zuidWestRoot = Join-Path $env:ProgramData "ZuidWest"
+$persistentRoot = Join-Path $zuidWestRoot "policy-update"
 $statePath = Join-Path $persistentRoot "state.json"
 $stagingRoot = Join-Path $persistentRoot "staging"
-$logDir = Join-Path $env:ProgramData "ZuidWest\Logs"
+$logDir = Join-Path $zuidWestRoot "Logs"
 $logPath = Join-Path $logDir "policy-auto-update.log"
 $lockPath = Join-Path $persistentRoot "update.lock"
 $selfPath = $PSCommandPath
@@ -408,7 +409,7 @@ try {
 
     # Redirect Get-DeployPath to the staging directory so policies.ps1 / applocker.ps1
     # read their inputs (policies/, bin/) from the freshly downloaded copy instead of
-    # C:\Windows\deploy. install.ps1 might be running concurrently; this keeps us isolated.
+    # the persistent deploy cache. install.ps1 might be running concurrently; this keeps us isolated.
     $env:WINDOWS11_BASELINE_DEPLOY_PATH = $stagingRoot
     try {
         . $commonPath

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -10,6 +10,17 @@
     for the HEAD commit SHA of the configured branch, and short-circuits when
     that SHA matches the SHAs already applied on this machine.
 
+    Rate-limit posture (GitHub unauthenticated cap is 60 req/h/IP):
+      - Conditional requests via If-None-Match. A 304 response does not count
+        against the rate limit, so steady-state polling burns ~0 quota per
+        machine until something actually changes on the branch.
+      - On 403/429 the X-RateLimit-Reset / Retry-After headers are honoured
+        and persisted to state.backoffUntil; subsequent ticks return early
+        until that time has passed.
+      - The scheduled-task trigger anchored by policyupdate.ps1 includes a
+        per-install minute offset so a fleet behind one NAT does not all
+        fire simultaneously.
+
     On a SHA that differs from either state.lastAppliedSha (policies need
     re-running) or state.lastSelfUpdateSha (the deployed copy of this script
     is out of date) the updater:
@@ -114,6 +125,103 @@ function Write-UpdateLog {
     Write-Output $line
 }
 
+function Get-BackoffUntilFromHeaders {
+    <#
+    .SYNOPSIS
+        Compute when polling may resume after a 403/429 from the GitHub API.
+
+    .DESCRIPTION
+        GitHub signals the primary-rate-limit reset via X-RateLimit-Reset
+        (Unix epoch seconds) and the secondary-rate-limit retry via
+        Retry-After (seconds). Falls back to a 15-minute window if neither
+        header is present. Output is a DateTime in UTC.
+    #>
+    [OutputType([datetime])]
+    param ($Headers)
+
+    if ($Headers) {
+        $resetRaw = $Headers["X-RateLimit-Reset"]
+        if ($resetRaw) {
+            $epoch = 0
+            if ([int]::TryParse([string]$resetRaw, [ref]$epoch) -and $epoch -gt 0) {
+                return [DateTimeOffset]::FromUnixTimeSeconds($epoch).UtcDateTime
+            }
+        }
+        $retryRaw = $Headers["Retry-After"]
+        if ($retryRaw) {
+            $seconds = 0
+            if ([int]::TryParse([string]$retryRaw, [ref]$seconds) -and $seconds -gt 0) {
+                return (Get-Date).ToUniversalTime().AddSeconds($seconds)
+            }
+        }
+    }
+
+    return (Get-Date).ToUniversalTime().AddMinutes(15)
+}
+
+function Invoke-GitHubApiCommitCheck {
+    <#
+    .SYNOPSIS
+        Conditional GET against /commits/<branch> with ETag caching.
+
+    .DESCRIPTION
+        Returns a pscustomobject with one of three shapes:
+          Status="ok"        : new data; .Sha and .Etag populated
+          Status="notModified": 304 response; ETag unchanged
+          Status="rateLimited": 403/429; .BackoffUntil populated
+        Network failure throws.
+    #>
+    [OutputType([pscustomobject])]
+    param (
+        [Parameter(Mandatory)][string]$Owner,
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$Branch,
+        [string]$Etag
+    )
+
+    $url = "https://api.github.com/repos/$Owner/$Repo/commits/$Branch"
+    $headers = @{
+        "User-Agent" = "windows11-baseline-policy-auto-update"
+        "Accept"     = "application/vnd.github+json"
+    }
+    if ($Etag) {
+        $headers["If-None-Match"] = $Etag
+    }
+
+    $previousProgress = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
+    try {
+        $response = Invoke-WebRequest -Uri $url -Headers $headers -UseBasicParsing -TimeoutSec 30
+    }
+    catch [System.Net.WebException] {
+        $webResponse = $_.Exception.Response
+        if ($null -eq $webResponse) {
+            throw
+        }
+        $statusCode = [int]$webResponse.StatusCode
+        if ($statusCode -eq 304) {
+            return [pscustomobject]@{ Status = "notModified" }
+        }
+        if ($statusCode -eq 403 -or $statusCode -eq 429) {
+            $until = Get-BackoffUntilFromHeaders -Headers $webResponse.Headers
+            return [pscustomobject]@{ Status = "rateLimited"; BackoffUntil = $until; StatusCode = $statusCode }
+        }
+        throw
+    }
+    finally {
+        $ProgressPreference = $previousProgress
+    }
+
+    $parsed = $response.Content | ConvertFrom-Json
+    $newEtag = $response.Headers["ETag"]
+    if ($newEtag -is [array]) { $newEtag = $newEtag[0] }
+    return [pscustomobject]@{
+        Status = "ok"
+        Sha    = $parsed.sha
+        Etag   = $newEtag
+    }
+}
+
 if (-not (Test-Path $logDir)) {
     New-Item -Path $logDir -ItemType Directory -Force | Out-Null
 }
@@ -150,7 +258,7 @@ try {
     $state = Read-StateOrBakLocal -Path $statePath
 
     # Ensure newer schema fields exist even when reading an older state file.
-    foreach ($field in @('lastSelfUpdateSha', 'lastCheckAt')) {
+    foreach ($field in @('lastSelfUpdateSha', 'lastEtag', 'backoffUntil', 'lastCheckAt', 'pollOffsetMinutes')) {
         if (-not ($state.PSObject.Properties.Name -contains $field)) {
             $state | Add-Member -NotePropertyName $field -NotePropertyValue $null -Force
         }
@@ -168,43 +276,73 @@ try {
         return
     }
 
+    # Honour any active backoff window before doing anything that touches the network.
+    if ($state.backoffUntil) {
+        $until = [datetime]::MinValue
+        if ([datetime]::TryParse([string]$state.backoffUntil, [ref]$until)) {
+            $untilUtc = $until.ToUniversalTime()
+            if ((Get-Date).ToUniversalTime() -lt $untilUtc) {
+                Write-UpdateLog "Backoff active until $($untilUtc.ToString('o')); skipping."
+                return
+            }
+        }
+    }
+
     Write-UpdateLog "Checking $repoOwner/$repoName@$branch (purpose=$purpose, ownership=$ownership)."
 
-    # Resolve the current branch HEAD SHA via the GitHub API.
-    $apiUrl = "https://api.github.com/repos/$repoOwner/$repoName/commits/$branch"
-    $headers = @{
-        "User-Agent" = "windows11-baseline-policy-auto-update"
-        "Accept"     = "application/vnd.github+json"
-    }
+    # Send a conditional request. Only the first request (or after a real change)
+    # spends a unit of the unauthenticated rate-limit budget; 304s are free.
+    $check = Invoke-GitHubApiCommitCheck -Owner $repoOwner -Repo $repoName -Branch $branch -Etag $state.lastEtag
 
-    $previousProgress = $ProgressPreference
-    $ProgressPreference = "SilentlyContinue"
-    try {
-        $apiResponse = Invoke-RestMethod -Uri $apiUrl -Headers $headers -UseBasicParsing -TimeoutSec 30
-    }
-    catch {
-        Write-UpdateLog "GitHub API call failed: $($_.Exception.Message)" "ERROR"
-        return
-    }
-    finally {
-        $ProgressPreference = $previousProgress
-    }
-
-    $remoteSha = $apiResponse.sha
-    if (-not $remoteSha) {
-        Write-UpdateLog "GitHub API response did not include a SHA; aborting." "ERROR"
-        return
-    }
-
-    # Record the check time even when there is nothing to apply.
     $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+    if ($check.Status -eq "rateLimited") {
+        $state.backoffUntil = $check.BackoffUntil.ToString("yyyy-MM-ddTHH:mm:ssZ")
+        $state.lastCheckAt = $now
+        Save-StateAtomicLocal -Path $statePath -State $state
+        Write-UpdateLog "GitHub API returned $($check.StatusCode); backoff until $($state.backoffUntil)." "WARN"
+        return
+    }
+
+    # Clear any stale backoff now that the API is answering normally again.
+    $state.backoffUntil = $null
     $state.lastCheckAt = $now
-    Save-StateAtomicLocal -Path $statePath -State $state
+
+    if ($check.Status -eq "notModified") {
+        # Server confirms our cached version is current. Use the SHA we last applied
+        # as the target so we can still retry a stalled self-copy from this run.
+        $remoteSha = $state.lastAppliedSha
+        if (-not $remoteSha) {
+            # We have an ETag but no recorded SHA (unusual). Force a fresh request
+            # next tick by dropping the ETag.
+            $state.lastEtag = $null
+            Save-StateAtomicLocal -Path $statePath -State $state
+            Write-UpdateLog "304 received but no lastAppliedSha; cleared ETag, will fetch full payload next tick." "WARN"
+            return
+        }
+        Write-UpdateLog "API returned 304 (no change); target SHA $remoteSha."
+        $pendingEtag = $state.lastEtag
+    }
+    else {
+        $remoteSha = $check.Sha
+        if (-not $remoteSha) {
+            Write-UpdateLog "GitHub API response did not include a SHA; aborting." "ERROR"
+            return
+        }
+        # The new ETag goes into state ONLY after a successful apply below; if we
+        # crash between here and there, the next tick will re-fetch the same SHA.
+        $pendingEtag = $check.Etag
+    }
 
     $policyCurrent = $state.lastAppliedSha -eq $remoteSha
     $selfCurrent = $state.lastSelfUpdateSha -eq $remoteSha
 
     if ($policyCurrent -and $selfCurrent) {
+        # Fully caught up. Persist lastCheckAt (and, on a fresh 200, the new ETag).
+        if ($check.Status -eq "ok") {
+            $state.lastEtag = $pendingEtag
+        }
+        Save-StateAtomicLocal -Path $statePath -State $state
         Write-UpdateLog "Already at $remoteSha; nothing to do."
         return
     }
@@ -302,6 +440,9 @@ try {
             # there does not force a re-apply on the next tick.
             $state.lastAppliedSha = $remoteSha
             $state.lastAppliedAt = $now
+            if ($check.Status -eq "ok") {
+                $state.lastEtag = $pendingEtag
+            }
             Save-StateAtomicLocal -Path $statePath -State $state
             Write-UpdateLog "Applied policy SHA $remoteSha."
         }
@@ -327,6 +468,9 @@ try {
             try {
                 Copy-Item -Path $newSelf -Destination $selfPath -Force
                 $state.lastSelfUpdateSha = $remoteSha
+                if ($check.Status -eq "ok") {
+                    $state.lastEtag = $pendingEtag
+                }
                 Save-StateAtomicLocal -Path $statePath -State $state
                 Write-UpdateLog "Auto-updater payload refreshed at $selfPath."
             }

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -1,0 +1,277 @@
+<#
+.SYNOPSIS
+    Scheduled-task payload that re-applies the ZuidWest baseline policy layer
+    whenever the configured GitHub branch advances.
+
+.DESCRIPTION
+    Runs as SYSTEM under the "ZuidWest\PolicyAutoUpdate" Scheduled Task.
+    Reads its deployment state from C:\ProgramData\ZuidWest\policy-update\state.json
+    (written at install time by scripts/policyupdate.ps1), asks the GitHub API
+    for the HEAD commit SHA of the configured branch, and short-circuits when
+    that SHA matches the SHA last applied to this machine.
+
+    On a new SHA the script:
+
+      1. Downloads the repository archive for that exact SHA into a staging
+         directory under C:\ProgramData\ZuidWest\policy-update\staging.
+      2. Points the baseline's deploy-path override
+         ($env:WINDOWS11_BASELINE_DEPLOY_PATH) at the staging directory so
+         the existing sub-scripts (which use Get-DeployPath / Join-DeployPath
+         from scripts/_common.ps1) operate on the freshly downloaded copy
+         without touching C:\Windows\deploy.
+      3. Runs each script listed in state.scriptsToReapply (default: policies,
+         applocker), passing systemPurpose / systemOwnership from the state
+         file. Sub-scripts are invoked directly, not via install.ps1, so the
+         updater is fully non-interactive.
+      4. Persists the new SHA, copies the latest version of this payload from
+         the staging directory back over its install location, and removes the
+         staging directory.
+
+    A single-instance file lock prevents overlapping runs when multiple
+    triggers fire close together (e.g. boot + logon).
+
+.NOTES
+    Source file: scripts/lib/policy-auto-updater.ps1
+    Installed to: C:\ProgramData\ZuidWest\policy-update\update.ps1
+    Deployed by: scripts/policyupdate.ps1
+    Log:         C:\ProgramData\ZuidWest\Logs\policy-auto-update.log
+#>
+
+$ErrorActionPreference = "Stop"
+
+$persistentRoot = Join-Path $env:ProgramData "ZuidWest\policy-update"
+$statePath = Join-Path $persistentRoot "state.json"
+$stagingRoot = Join-Path $persistentRoot "staging"
+$logDir = Join-Path $env:ProgramData "ZuidWest\Logs"
+$logPath = Join-Path $logDir "policy-auto-update.log"
+$lockPath = Join-Path $persistentRoot "update.lock"
+$selfPath = $PSCommandPath
+
+function Write-UpdateLog {
+    param (
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [ValidateSet("INFO", "WARN", "ERROR")]
+        [string]$Level = "INFO"
+    )
+
+    $timestamp = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssK")
+    $line = "$timestamp [$Level] $Message"
+    try {
+        Add-Content -Path $logPath -Value $line -Encoding UTF8 -ErrorAction Stop
+    }
+    catch {
+        # Best-effort logging: never let the log writer itself break the updater.
+        $null = $_
+    }
+    Write-Output $line
+}
+
+if (-not (Test-Path $logDir)) {
+    New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+# Rotate the log once it grows past ~5 MB to keep deploys tidy without losing recent history.
+if (Test-Path $logPath) {
+    try {
+        if ((Get-Item $logPath).Length -gt 5MB) {
+            Move-Item -Path $logPath -Destination "$logPath.1" -Force
+        }
+    }
+    catch {
+        # Non-fatal: continue writing to the existing log.
+        $null = $_
+    }
+}
+
+# Single-instance lock. Boot + logon triggers can fire seconds apart; ignore overlapping runs.
+$lockStream = $null
+try {
+    $lockStream = [System.IO.File]::Open($lockPath, 'Create', 'Write', 'None')
+}
+catch {
+    Write-UpdateLog "Another auto-update run is in progress; skipping."
+    return
+}
+
+try {
+    if (-not (Test-Path $statePath)) {
+        Write-UpdateLog "State file missing at $statePath; refusing to run." "ERROR"
+        return
+    }
+
+    $state = Get-Content -Path $statePath -Raw | ConvertFrom-Json
+
+    $repoOwner = $state.repoOwner
+    $repoName = $state.repoName
+    $branch = $state.branch
+    $purpose = $state.systemPurpose
+    $ownership = $state.systemOwnership
+    $scriptsToReapply = @($state.scriptsToReapply)
+
+    if (-not $repoOwner -or -not $repoName -or -not $branch) {
+        Write-UpdateLog "State file is missing repoOwner/repoName/branch; aborting." "ERROR"
+        return
+    }
+
+    Write-UpdateLog "Checking $repoOwner/$repoName@$branch (purpose=$purpose, ownership=$ownership)."
+
+    # Resolve the current branch HEAD SHA via the GitHub API.
+    $apiUrl = "https://api.github.com/repos/$repoOwner/$repoName/commits/$branch"
+    $headers = @{
+        "User-Agent" = "windows11-baseline-policy-auto-update"
+        "Accept"     = "application/vnd.github+json"
+    }
+
+    $previousProgress = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
+    try {
+        $apiResponse = Invoke-RestMethod -Uri $apiUrl -Headers $headers -UseBasicParsing -TimeoutSec 30
+    }
+    catch {
+        Write-UpdateLog "GitHub API call failed: $($_.Exception.Message)" "ERROR"
+        return
+    }
+    finally {
+        $ProgressPreference = $previousProgress
+    }
+
+    $remoteSha = $apiResponse.sha
+    if (-not $remoteSha) {
+        Write-UpdateLog "GitHub API response did not include a SHA; aborting." "ERROR"
+        return
+    }
+
+    # Record the check time even when there is nothing to apply.
+    $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $state.lastCheckAt = $now
+    $state | ConvertTo-Json -Depth 4 | Set-Content -Path $statePath -Encoding UTF8
+
+    if ($state.lastAppliedSha -eq $remoteSha) {
+        Write-UpdateLog "Already at $remoteSha; nothing to do."
+        return
+    }
+
+    Write-UpdateLog "New SHA $remoteSha (was $($state.lastAppliedSha)); preparing staged apply."
+
+    if (Test-Path $stagingRoot) {
+        Remove-Item -Path $stagingRoot -Recurse -Force
+    }
+    New-Item -Path $stagingRoot -ItemType Directory -Force | Out-Null
+
+    $zipUrl = "https://github.com/$repoOwner/$repoName/archive/$remoteSha.zip"
+    $zipPath = Join-Path $stagingRoot "repo.zip"
+
+    $previousProgress = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
+    try {
+        Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing -TimeoutSec 120
+    }
+    catch {
+        Write-UpdateLog "Failed to download repo archive: $($_.Exception.Message)" "ERROR"
+        return
+    }
+    finally {
+        $ProgressPreference = $previousProgress
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $stagingRoot)
+    Remove-Item -Path $zipPath -Force
+
+    # GitHub archives extract to <repo>-<sha>/...; flatten so $stagingRoot is the repo root.
+    $extracted = Get-ChildItem -Path $stagingRoot -Directory | Select-Object -First 1
+    if (-not $extracted) {
+        Write-UpdateLog "Extracted archive did not contain a directory; aborting." "ERROR"
+        return
+    }
+    Get-ChildItem -Path $extracted.FullName -Force | Move-Item -Destination $stagingRoot -Force
+    Remove-Item -Path $extracted.FullName -Recurse -Force
+
+    $commonPath = Join-Path $stagingRoot "scripts\_common.ps1"
+    if (-not (Test-Path $commonPath)) {
+        Write-UpdateLog "Staging is missing scripts\_common.ps1; aborting." "ERROR"
+        return
+    }
+
+    # Redirect Get-DeployPath to the staging directory so policies.ps1 / applocker.ps1
+    # read their inputs (policies/, bin/) from the freshly downloaded copy instead of
+    # C:\Windows\deploy. install.ps1 might be running concurrently; this keeps us isolated.
+    $env:WINDOWS11_BASELINE_DEPLOY_PATH = $stagingRoot
+    try {
+        . $commonPath
+
+        foreach ($scriptName in $scriptsToReapply) {
+            $candidates = @(
+                (Join-Path $stagingRoot "scripts\$scriptName.ps1"),
+                (Join-Path $stagingRoot "scripts\_$scriptName.ps1")
+            )
+            $scriptPath = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+            if (-not $scriptPath) {
+                Write-UpdateLog "Script '$scriptName' not found in staging; skipping." "WARN"
+                continue
+            }
+
+            $detectedParams = Get-ScriptParameterNames -Path $scriptPath
+            $scriptParams = @{}
+            $unsupportedParam = $null
+            foreach ($paramName in $detectedParams) {
+                switch ($paramName) {
+                    "systemPurpose" { $scriptParams["systemPurpose"] = $purpose }
+                    "systemOwnership" { $scriptParams["systemOwnership"] = $ownership }
+                    default { $unsupportedParam = $paramName }
+                }
+            }
+
+            if ($unsupportedParam) {
+                Write-UpdateLog "Script '$scriptName' declares -$unsupportedParam which the auto-updater cannot supply; aborting." "ERROR"
+                return
+            }
+
+            Write-UpdateLog "Running $scriptName..."
+            $childOutput = & $scriptPath @scriptParams *>&1
+            foreach ($entry in $childOutput) {
+                $text = if ($entry -is [string]) { $entry } else { $entry.ToString() }
+                foreach ($line in ($text -split "`r?`n")) {
+                    if ($line) {
+                        Write-UpdateLog "[$scriptName] $line"
+                    }
+                }
+            }
+        }
+    }
+    finally {
+        Remove-Item -Path "Env:WINDOWS11_BASELINE_DEPLOY_PATH" -ErrorAction SilentlyContinue
+    }
+
+    $state.lastAppliedSha = $remoteSha
+    $state.lastAppliedAt = $now
+    $state | ConvertTo-Json -Depth 4 | Set-Content -Path $statePath -Encoding UTF8
+
+    # Refresh the deployed copy of this script so updater fixes shipped via main propagate.
+    $newSelf = Join-Path $stagingRoot "scripts\lib\policy-auto-updater.ps1"
+    if (Test-Path $newSelf) {
+        try {
+            Copy-Item -Path $newSelf -Destination $selfPath -Force
+            Write-UpdateLog "Auto-updater payload refreshed at $selfPath."
+        }
+        catch {
+            Write-UpdateLog "Could not refresh auto-updater payload (will retry next run): $($_.Exception.Message)" "WARN"
+        }
+    }
+
+    Write-UpdateLog "Applied $remoteSha."
+}
+catch {
+    Write-UpdateLog "Auto-update failed: $($_.Exception.Message)" "ERROR"
+}
+finally {
+    if ($lockStream) {
+        $lockStream.Dispose()
+    }
+    Remove-Item -Path $lockPath -ErrorAction SilentlyContinue
+    if (Test-Path $stagingRoot) {
+        Remove-Item -Path $stagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -8,9 +8,11 @@
     Reads its deployment state from C:\ProgramData\ZuidWest\policy-update\state.json
     (written at install time by scripts/policyupdate.ps1), asks the GitHub API
     for the HEAD commit SHA of the configured branch, and short-circuits when
-    that SHA matches the SHA last applied to this machine.
+    that SHA matches the SHAs already applied on this machine.
 
-    On a new SHA the script:
+    On a SHA that differs from either state.lastAppliedSha (policies need
+    re-running) or state.lastSelfUpdateSha (the deployed copy of this script
+    is out of date) the updater:
 
       1. Downloads the repository archive for that exact SHA into a staging
          directory under C:\ProgramData\ZuidWest\policy-update\staging.
@@ -19,13 +21,16 @@
          the existing sub-scripts (which use Get-DeployPath / Join-DeployPath
          from scripts/_common.ps1) operate on the freshly downloaded copy
          without touching C:\Windows\deploy.
-      3. Runs each script listed in state.scriptsToReapply (default: policies,
-         applocker), passing systemPurpose / systemOwnership from the state
-         file. Sub-scripts are invoked directly, not via install.ps1, so the
-         updater is fully non-interactive.
-      4. Persists the new SHA, copies the latest version of this payload from
-         the staging directory back over its install location, and removes the
-         staging directory.
+      3. If policy is stale: runs each script listed in state.scriptsToReapply
+         (default: policies, applocker), passing systemPurpose /
+         systemOwnership from the state file. Sub-scripts are invoked
+         directly, not via install.ps1, so the updater is fully
+         non-interactive.
+      4. If the self-copy is stale: copies the staged
+         scripts/lib/policy-auto-updater.ps1 over this script.
+      5. Persists progress per stage. Policy SHA and self-update SHA are
+         tracked separately, so a self-copy that fails (file locked, AV
+         scanning) does not prevent the retry on the next tick.
 
     State writes use Save-StateAtomicLocal (defined inline at startup so it
     is available before the staged scripts/_common.ps1 is sourced). Reads use
@@ -144,6 +149,13 @@ try {
 
     $state = Read-StateOrBakLocal -Path $statePath
 
+    # Ensure newer schema fields exist even when reading an older state file.
+    foreach ($field in @('lastSelfUpdateSha', 'lastCheckAt')) {
+        if (-not ($state.PSObject.Properties.Name -contains $field)) {
+            $state | Add-Member -NotePropertyName $field -NotePropertyValue $null -Force
+        }
+    }
+
     $repoOwner = $state.repoOwner
     $repoName = $state.repoName
     $branch = $state.branch
@@ -189,12 +201,15 @@ try {
     $state.lastCheckAt = $now
     Save-StateAtomicLocal -Path $statePath -State $state
 
-    if ($state.lastAppliedSha -eq $remoteSha) {
+    $policyCurrent = $state.lastAppliedSha -eq $remoteSha
+    $selfCurrent = $state.lastSelfUpdateSha -eq $remoteSha
+
+    if ($policyCurrent -and $selfCurrent) {
         Write-UpdateLog "Already at $remoteSha; nothing to do."
         return
     }
 
-    Write-UpdateLog "New SHA $remoteSha (was $($state.lastAppliedSha)); preparing staged apply."
+    Write-UpdateLog "Stale: policy=$(-not $policyCurrent), self=$(-not $selfCurrent). Target SHA $remoteSha; preparing staged apply."
 
     if (Test-Path $stagingRoot) {
         Remove-Item -Path $stagingRoot -Recurse -Force
@@ -243,66 +258,83 @@ try {
     try {
         . $commonPath
 
-        foreach ($scriptName in $scriptsToReapply) {
-            $candidates = @(
-                (Join-Path $stagingRoot "scripts\$scriptName.ps1"),
-                (Join-Path $stagingRoot "scripts\_$scriptName.ps1")
-            )
-            $scriptPath = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-            if (-not $scriptPath) {
-                Write-UpdateLog "Script '$scriptName' not found in staging; skipping." "WARN"
-                continue
-            }
-
-            $detectedParams = Get-ScriptParameterNames -Path $scriptPath
-            $scriptParams = @{}
-            $unsupportedParam = $null
-            foreach ($paramName in $detectedParams) {
-                switch ($paramName) {
-                    "systemPurpose" { $scriptParams["systemPurpose"] = $purpose }
-                    "systemOwnership" { $scriptParams["systemOwnership"] = $ownership }
-                    default { $unsupportedParam = $paramName }
+        if (-not $policyCurrent) {
+            foreach ($scriptName in $scriptsToReapply) {
+                $candidates = @(
+                    (Join-Path $stagingRoot "scripts\$scriptName.ps1"),
+                    (Join-Path $stagingRoot "scripts\_$scriptName.ps1")
+                )
+                $scriptPath = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+                if (-not $scriptPath) {
+                    Write-UpdateLog "Script '$scriptName' not found in staging; skipping." "WARN"
+                    continue
                 }
-            }
 
-            if ($unsupportedParam) {
-                Write-UpdateLog "Script '$scriptName' declares -$unsupportedParam which the auto-updater cannot supply; aborting." "ERROR"
-                return
-            }
+                $detectedParams = Get-ScriptParameterNames -Path $scriptPath
+                $scriptParams = @{}
+                $unsupportedParam = $null
+                foreach ($paramName in $detectedParams) {
+                    switch ($paramName) {
+                        "systemPurpose" { $scriptParams["systemPurpose"] = $purpose }
+                        "systemOwnership" { $scriptParams["systemOwnership"] = $ownership }
+                        default { $unsupportedParam = $paramName }
+                    }
+                }
 
-            Write-UpdateLog "Running $scriptName..."
-            $childOutput = & $scriptPath @scriptParams *>&1
-            foreach ($entry in $childOutput) {
-                $text = if ($entry -is [string]) { $entry } else { $entry.ToString() }
-                foreach ($line in ($text -split "`r?`n")) {
-                    if ($line) {
-                        Write-UpdateLog "[$scriptName] $line"
+                if ($unsupportedParam) {
+                    Write-UpdateLog "Script '$scriptName' declares -$unsupportedParam which the auto-updater cannot supply; aborting." "ERROR"
+                    return
+                }
+
+                Write-UpdateLog "Running $scriptName..."
+                $childOutput = & $scriptPath @scriptParams *>&1
+                foreach ($entry in $childOutput) {
+                    $text = if ($entry -is [string]) { $entry } else { $entry.ToString() }
+                    foreach ($line in ($text -split "`r?`n")) {
+                        if ($line) {
+                            Write-UpdateLog "[$scriptName] $line"
+                        }
                     }
                 }
             }
+
+            # Persist policy progress before attempting the self-copy so a failure
+            # there does not force a re-apply on the next tick.
+            $state.lastAppliedSha = $remoteSha
+            $state.lastAppliedAt = $now
+            Save-StateAtomicLocal -Path $statePath -State $state
+            Write-UpdateLog "Applied policy SHA $remoteSha."
+        }
+        else {
+            Write-UpdateLog "Policy already at $remoteSha; only refreshing the deployed updater."
         }
     }
     finally {
         Remove-Item -Path "Env:WINDOWS11_BASELINE_DEPLOY_PATH" -ErrorAction SilentlyContinue
     }
 
-    $state.lastAppliedSha = $remoteSha
-    $state.lastAppliedAt = $now
-    Save-StateAtomicLocal -Path $statePath -State $state
-
-    # Refresh the deployed copy of this script so updater fixes shipped via main propagate.
-    $newSelf = Join-Path $stagingRoot "scripts\lib\policy-auto-updater.ps1"
-    if (Test-Path $newSelf) {
-        try {
-            Copy-Item -Path $newSelf -Destination $selfPath -Force
-            Write-UpdateLog "Auto-updater payload refreshed at $selfPath."
+    if (-not $selfCurrent) {
+        # Refresh the deployed copy of this script so updater fixes shipped via main
+        # propagate. Track success separately from the policy SHA: a failed copy
+        # (file locked, AV scan) will be retried on the next tick because
+        # lastSelfUpdateSha stays behind lastAppliedSha and the short-circuit at
+        # the top of the run only fires when BOTH match the target.
+        $newSelf = Join-Path $stagingRoot "scripts\lib\policy-auto-updater.ps1"
+        if (-not (Test-Path $newSelf)) {
+            Write-UpdateLog "Staging does not contain scripts\lib\policy-auto-updater.ps1; skipping self-update." "WARN"
         }
-        catch {
-            Write-UpdateLog "Could not refresh auto-updater payload (will retry next run): $($_.Exception.Message)" "WARN"
+        else {
+            try {
+                Copy-Item -Path $newSelf -Destination $selfPath -Force
+                $state.lastSelfUpdateSha = $remoteSha
+                Save-StateAtomicLocal -Path $statePath -State $state
+                Write-UpdateLog "Auto-updater payload refreshed at $selfPath."
+            }
+            catch {
+                Write-UpdateLog "Self-update copy failed (will retry next run): $($_.Exception.Message)" "WARN"
+            }
         }
     }
-
-    Write-UpdateLog "Applied $remoteSha."
 }
 catch {
     Write-UpdateLog "Auto-update failed: $($_.Exception.Message)" "ERROR"

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -4,60 +4,17 @@
     whenever the configured GitHub branch advances.
 
 .DESCRIPTION
-    Runs as SYSTEM under the "ZuidWest\PolicyAutoUpdate" Scheduled Task.
-    Reads its deployment state from C:\ProgramData\ZuidWest\policy-update\state.json
-    (written at install time by scripts/policyupdate.ps1), reads github.com's
-    public commits.atom feed for the configured branch to learn the HEAD
-    commit SHA, and short-circuits when that SHA matches the SHAs already
-    applied on this machine.
+    Runs as SYSTEM. It checks GitHub's commits.atom feed for the configured
+    branch, downloads the exact SHA into staging, runs the configured policy
+    scripts from that staged copy, and refreshes this updater when needed.
 
-    Rate-limit posture:
-      - The SHA check goes to the public atom feed at
-        https://github.com/<owner>/<repo>/commits/<branch>.atom,
-        not the REST API. github.com is not bound by the 60 req/h/IP
-        unauthenticated REST API limit, so a fleet-wide hourly poll does
-        not compete for that budget.
-      - On 429 from github.com the response headers are honoured per
-        GitHub's REST API best practices (the github.com general rate
-        limiter uses the same conventions): Retry-After first, then
-        X-RateLimit-Reset only when X-RateLimit-Remaining is 0, with a
-        1-minute floor fallback. The resulting wake time is persisted to
-        state.backoffUntil and short-circuits subsequent ticks until it
-        passes.
-      - The scheduled-task triggers anchored by policyupdate.ps1 use
-        -RandomDelay so startup, logon, and hourly checks do not fire in
-        lockstep across the fleet.
+    State is stored under C:\ProgramData\ZuidWest\policy-update. Policy and
+    self-update SHAs are tracked separately so one successful stage is not
+    repeated because the other failed. State writes are atomic with a .bak
+    fallback; a file lock drops overlapping boot/logon runs.
 
-    On a SHA that differs from either state.lastAppliedSha (policies need
-    re-running) or state.lastSelfUpdateSha (the deployed copy of this script
-    is out of date) the updater:
-
-      1. Downloads the repository archive for that exact SHA into a staging
-         directory under C:\ProgramData\ZuidWest\policy-update\staging.
-      2. Points the baseline's deploy-path override
-         ($env:WINDOWS11_BASELINE_DEPLOY_PATH) at the staging directory so
-         the existing sub-scripts (which use Get-DeployPath / Join-DeployPath
-         from scripts/_common.ps1) operate on the freshly downloaded copy
-         without touching the persistent deploy cache.
-      3. If policy is stale: runs each script listed in state.scriptsToReapply
-         (default: policies, applocker), passing systemPurpose /
-         systemOwnership from the state file. Sub-scripts are invoked
-         directly, not via install.ps1, so the updater is fully
-         non-interactive.
-      4. If the self-copy is stale: copies the staged
-         scripts/lib/policy-auto-updater.ps1 over this script.
-      5. Persists progress per stage. Policy SHA and self-update SHA are
-         tracked separately, so a self-copy that fails (file locked, AV
-         scanning) does not prevent the retry on the next tick.
-
-    State writes use Save-StateAtomicLocal (defined inline at startup so it
-    is available before the staged scripts/_common.ps1 is sourced). Reads use
-    Read-StateOrBakLocal, which falls back to "$statePath.bak" if the main
-    file fails to parse. This protects the updater from being permanently
-    bricked by a power loss or crash mid-write.
-
-    A single-instance file lock prevents overlapping runs when multiple
-    triggers fire close together (e.g. boot + logon).
+    The updater uses the public atom feed instead of api.github.com and honors
+    Retry-After / X-RateLimit-* backoff headers when github.com rate-limits.
 
 .NOTES
     Source file: scripts/lib/policy-auto-updater.ps1
@@ -77,10 +34,7 @@ $logPath = Join-Path $logDir "policy-auto-update.log"
 $lockPath = Join-Path $persistentRoot "update.lock"
 $selfPath = $PSCommandPath
 
-# Inline copies of the atomic state helpers. The canonical implementations
-# live in scripts/_common.ps1, but we need them before the staged _common.ps1
-# is sourced (we have to read state.json to know which repo to download from).
-# Re-defining them after dot-sourcing is harmless: the bodies are identical.
+# Needed before staged _common.ps1 is available.
 function Save-StateAtomicLocal {
     param (
         [Parameter(Mandatory)][string]$Path,
@@ -127,7 +81,7 @@ function Write-UpdateLog {
         Add-Content -Path $logPath -Value $line -Encoding UTF8 -ErrorAction Stop
     }
     catch {
-        # Best-effort logging: never let the log writer itself break the updater.
+        # Logging must never break the updater.
         $null = $_
     }
     Write-Output $line
@@ -139,21 +93,9 @@ function Get-BackoffUntilFromHeaders {
         Compute when polling may resume after a 403/429 from github.com.
 
     .DESCRIPTION
-        Implements the resume-time logic from GitHub's REST API best practices
-        guide (https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api).
-        Although the auto-updater talks to github.com's commits.atom feed and
-        not to api.github.com, github.com's general rate limiter uses the same
-        Retry-After / X-RateLimit-* header conventions, so the same ordering
-        applies:
-
-          1. If Retry-After is set, wait that many seconds (it carries the
-             secondary / abuse-detection limit and takes precedence).
-          2. Otherwise, if X-RateLimit-Remaining is 0, wait until
-             X-RateLimit-Reset (Unix epoch seconds, the primary-limit reset).
-          3. Otherwise fall back to a 1-minute floor; subsequent scheduled
-             ticks effectively give us exponential spacing across the hour.
-
-        Output is a DateTime in UTC.
+        Follows GitHub's retry ordering: Retry-After first, then
+        X-RateLimit-Reset when remaining is 0, otherwise a 1-minute floor.
+        Returns a UTC DateTime.
     #>
     [OutputType([datetime])]
     param ($Headers)
@@ -164,7 +106,6 @@ function Get-BackoffUntilFromHeaders {
         return $now.AddMinutes(1)
     }
 
-    # 1. Retry-After wins when set: secondary rate / abuse detection.
     $retryRaw = $Headers["Retry-After"]
     if ($retryRaw) {
         $seconds = 0
@@ -173,7 +114,6 @@ function Get-BackoffUntilFromHeaders {
         }
     }
 
-    # 2. Primary limit exhausted (Remaining == 0): honour X-RateLimit-Reset.
     $remaining = -1
     $remainingRaw = $Headers["X-RateLimit-Remaining"]
     if ($remainingRaw) {
@@ -189,7 +129,6 @@ function Get-BackoffUntilFromHeaders {
         }
     }
 
-    # 3. No header hints: GitHub recommends at least one minute before retry.
     return $now.AddMinutes(1)
 }
 
@@ -199,25 +138,8 @@ function Invoke-AtomBranchCheck {
         Resolve a branch's HEAD commit SHA via the public commits.atom feed.
 
     .DESCRIPTION
-        Fetches https://github.com/<owner>/<repo>/commits/<branch>.atom and
-        regex-extracts the first 40-char SHA. The atom feed reflects the
-        branch HEAD in real time (no CI required to maintain a sentinel
-        file) and runs against github.com rather than api.github.com, so
-        it does not consume the unauthenticated REST API budget.
-
-        The first <entry> in the feed corresponds to the most recent
-        commit, and every entry id has the form
-        "tag:github.com,2008:Grit::Commit/<sha40>". Matching that pattern
-        with -match returns the first occurrence, which is the HEAD
-        commit. Regex over the body is used instead of full XML parsing
-        because it is faster, allocation-light, and tolerant of unrelated
-        atom-format changes (e.g. new namespaces).
-
-        Returns a pscustomobject:
-          Status="ok"          : .Sha populated with the 40-char SHA
-          Status="rateLimited" : .BackoffUntil populated (DateTime UTC) and
-                                 .StatusCode
-        Other errors throw (network failures, parse failures, 404s).
+        Returns Status="ok" with .Sha, or Status="rateLimited" with
+        .BackoffUntil and .StatusCode. Other errors throw.
     #>
     [OutputType([pscustomobject])]
     param (
@@ -270,7 +192,7 @@ if (-not (Test-Path $logDir)) {
     New-Item -Path $logDir -ItemType Directory -Force | Out-Null
 }
 
-# Rotate the log once it grows past ~5 MB to keep deploys tidy without losing recent history.
+# Keep one rotated log generation.
 if (Test-Path $logPath) {
     try {
         if ((Get-Item $logPath).Length -gt 5MB) {
@@ -278,12 +200,11 @@ if (Test-Path $logPath) {
         }
     }
     catch {
-        # Non-fatal: continue writing to the existing log.
         $null = $_
     }
 }
 
-# Single-instance lock. Boot + logon triggers can fire seconds apart; ignore overlapping runs.
+# Boot and logon triggers can overlap.
 $lockStream = $null
 try {
     $lockStream = [System.IO.File]::Open($lockPath, 'Create', 'Write', 'None')
@@ -301,7 +222,7 @@ try {
 
     $state = Read-StateOrBakLocal -Path $statePath
 
-    # Ensure newer schema fields exist even when reading an older state file.
+    # Backfill newer state fields.
     $schemaDefaults = @{
         enabled           = $true
         lastSelfUpdateSha = $null
@@ -338,7 +259,7 @@ try {
         return
     }
 
-    # Honour any active backoff window before doing anything that touches the network.
+    # Do not touch the network during backoff.
     if ($state.backoffUntil) {
         $until = [datetime]::MinValue
         if ([datetime]::TryParse([string]$state.backoffUntil, [ref]$until)) {
@@ -364,7 +285,7 @@ try {
         return
     }
 
-    # Clear any stale backoff now that github.com is answering normally again.
+    # Clear stale backoff after a successful check.
     $state.backoffUntil = $null
     $state.lastCheckAt = $now
 
@@ -410,7 +331,7 @@ try {
     [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $stagingRoot)
     Remove-Item -Path $zipPath -Force
 
-    # GitHub archives extract to <repo>-<sha>/...; flatten so $stagingRoot is the repo root.
+    # Flatten GitHub's <repo>-<sha>/ archive wrapper.
     $extracted = Get-ChildItem -Path $stagingRoot -Directory | Select-Object -First 1
     if (-not $extracted) {
         Write-UpdateLog "Extracted archive did not contain a directory; aborting." "ERROR"
@@ -425,9 +346,7 @@ try {
         return
     }
 
-    # Redirect Get-DeployPath to the staging directory so policies.ps1 / applocker.ps1
-    # read their inputs (policies/, bin/) from the freshly downloaded copy instead of
-    # the persistent deploy cache. install.ps1 might be running concurrently; this keeps us isolated.
+    # Run sub-scripts against staging, isolated from any concurrent install.
     $env:WINDOWS11_BASELINE_DEPLOY_PATH = $stagingRoot
     try {
         . $commonPath
@@ -440,9 +359,7 @@ try {
                 )
                 $scriptPath = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
                 if (-not $scriptPath) {
-                    # Hard fail. Skipping would let lastAppliedSha advance and
-                    # short-circuit the missing script forever, even though the
-                    # operator explicitly requested it.
+                    # Do not advance lastAppliedSha when requested scripts are missing.
                     Write-UpdateLog "Script '$scriptName' is in scriptsToReapply but not found in staging; aborting (lastAppliedSha not advanced)." "ERROR"
                     return
                 }
@@ -475,8 +392,7 @@ try {
                 }
             }
 
-            # Persist policy progress before attempting the self-copy so a failure
-            # there does not force a re-apply on the next tick.
+            # Self-update failure should not force policy re-apply.
             $state.lastAppliedSha = $remoteSha
             $state.lastAppliedAt = $now
             Save-StateAtomicLocal -Path $statePath -State $state
@@ -491,11 +407,7 @@ try {
     }
 
     if (-not $selfCurrent) {
-        # Refresh the deployed copy of this script so updater fixes shipped via main
-        # propagate. Track success separately from the policy SHA: a failed copy
-        # (file locked, AV scan) will be retried on the next tick because
-        # lastSelfUpdateSha stays behind lastAppliedSha and the short-circuit at
-        # the top of the run only fires when BOTH match the target.
+        # Retry independently via lastSelfUpdateSha when this copy fails.
         $newSelf = Join-Path $stagingRoot "scripts\lib\policy-auto-updater.ps1"
         if (-not (Test-Path $newSelf)) {
             Write-UpdateLog "Staging does not contain scripts\lib\policy-auto-updater.ps1; skipping self-update." "WARN"

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -302,10 +302,28 @@ try {
     $state = Read-StateOrBakLocal -Path $statePath
 
     # Ensure newer schema fields exist even when reading an older state file.
-    foreach ($field in @('lastSelfUpdateSha', 'backoffUntil', 'lastCheckAt')) {
+    $schemaDefaults = @{
+        enabled           = $true
+        lastSelfUpdateSha = $null
+        backoffUntil      = $null
+        lastCheckAt       = $null
+    }
+    foreach ($field in $schemaDefaults.Keys) {
         if (-not ($state.PSObject.Properties.Name -contains $field)) {
-            $state | Add-Member -NotePropertyName $field -NotePropertyValue $null -Force
+            $state | Add-Member -NotePropertyName $field -NotePropertyValue $schemaDefaults[$field] -Force
         }
+    }
+
+    $enabled = $true
+    try {
+        $enabled = [System.Convert]::ToBoolean($state.enabled)
+    }
+    catch {
+        Write-UpdateLog "State field 'enabled' is not a boolean-compatible value; treating auto-update as enabled." "WARN"
+    }
+    if (-not $enabled) {
+        Write-UpdateLog "Auto-update disabled by state.enabled=false; skipping."
+        return
     }
 
     $repoOwner = $state.repoOwner

--- a/scripts/lib/policy-auto-updater.ps1
+++ b/scripts/lib/policy-auto-updater.ps1
@@ -10,19 +10,19 @@
     for the HEAD commit SHA of the configured branch, and short-circuits when
     that SHA matches the SHAs already applied on this machine.
 
-    Rate-limit posture (GitHub unauthenticated cap is 60 req/h/IP):
-      - Conditional requests via If-None-Match always save bandwidth on the
-        steady-state poll. Whether the 304 also avoids spending rate-limit
-        quota is documented as conditional on the request being
-        authenticated, so this implementation does not rely on it for the
-        unauthenticated case; the backoff handler below is the actual
-        defence.
-      - On 403/429 the response headers are honoured per GitHub's REST API
-        best practices: Retry-After takes precedence (it signals the
-        secondary / abuse-detection limit), then X-RateLimit-Reset is used
-        only when X-RateLimit-Remaining is 0, with a 1-minute floor
-        fallback. The resulting wake time is persisted to state.backoffUntil
-        and short-circuits subsequent ticks until it passes.
+    Rate-limit posture:
+      - The SHA check goes to the public atom feed at
+        https://github.com/<owner>/<repo>/commits/<branch>.atom,
+        not the REST API. github.com is not bound by the 60 req/h/IP
+        unauthenticated REST API limit, so a fleet-wide hourly poll does
+        not compete for that budget.
+      - On 429 from github.com the response headers are honoured per
+        GitHub's REST API best practices (the github.com general rate
+        limiter uses the same conventions): Retry-After first, then
+        X-RateLimit-Reset only when X-RateLimit-Remaining is 0, with a
+        1-minute floor fallback. The resulting wake time is persisted to
+        state.backoffUntil and short-circuits subsequent ticks until it
+        passes.
       - The scheduled-task trigger anchored by policyupdate.ps1 uses
         -RandomDelay so each fleet member fires at a different minute
         within the hour.
@@ -187,33 +187,43 @@ function Get-BackoffUntilFromHeaders {
     return $now.AddMinutes(1)
 }
 
-function Invoke-GitHubApiCommitCheck {
+function Invoke-AtomBranchCheck {
     <#
     .SYNOPSIS
-        Conditional GET against /commits/<branch> with ETag caching.
+        Resolve a branch's HEAD commit SHA via the public commits.atom feed.
 
     .DESCRIPTION
-        Returns a pscustomobject with one of three shapes:
-          Status="ok"        : new data; .Sha and .Etag populated
-          Status="notModified": 304 response; ETag unchanged
-          Status="rateLimited": 403/429; .BackoffUntil populated
-        Network failure throws.
+        Fetches https://github.com/<owner>/<repo>/commits/<branch>.atom and
+        regex-extracts the first 40-char SHA. The atom feed reflects the
+        branch HEAD in real time (no CI required to maintain a sentinel
+        file) and runs against github.com rather than api.github.com, so
+        it does not consume the unauthenticated REST API budget.
+
+        The first <entry> in the feed corresponds to the most recent
+        commit, and every entry id has the form
+        "tag:github.com,2008:Grit::Commit/<sha40>". Matching that pattern
+        with -match returns the first occurrence, which is the HEAD
+        commit. Regex over the body is used instead of full XML parsing
+        because it is faster, allocation-light, and tolerant of unrelated
+        atom-format changes (e.g. new namespaces).
+
+        Returns a pscustomobject:
+          Status="ok"          : .Sha populated with the 40-char SHA
+          Status="rateLimited" : .BackoffUntil populated (DateTime UTC) and
+                                 .StatusCode
+        Other errors throw (network failures, parse failures, 404s).
     #>
     [OutputType([pscustomobject])]
     param (
         [Parameter(Mandatory)][string]$Owner,
         [Parameter(Mandatory)][string]$Repo,
-        [Parameter(Mandatory)][string]$Branch,
-        [string]$Etag
+        [Parameter(Mandatory)][string]$Branch
     )
 
-    $url = "https://api.github.com/repos/$Owner/$Repo/commits/$Branch"
+    $url = "https://github.com/$Owner/$Repo/commits/$Branch.atom"
     $headers = @{
         "User-Agent" = "windows11-baseline-policy-auto-update"
-        "Accept"     = "application/vnd.github+json"
-    }
-    if ($Etag) {
-        $headers["If-None-Match"] = $Etag
+        "Accept"     = "application/atom+xml"
     }
 
     $previousProgress = $ProgressPreference
@@ -227,12 +237,12 @@ function Invoke-GitHubApiCommitCheck {
             throw
         }
         $statusCode = [int]$webResponse.StatusCode
-        if ($statusCode -eq 304) {
-            return [pscustomobject]@{ Status = "notModified" }
-        }
         if ($statusCode -eq 403 -or $statusCode -eq 429) {
             $until = Get-BackoffUntilFromHeaders -Headers $webResponse.Headers
             return [pscustomobject]@{ Status = "rateLimited"; BackoffUntil = $until; StatusCode = $statusCode }
+        }
+        if ($statusCode -eq 404) {
+            throw "Atom feed at $url returned 404; branch '$Branch' may not exist."
         }
         throw
     }
@@ -240,14 +250,14 @@ function Invoke-GitHubApiCommitCheck {
         $ProgressPreference = $previousProgress
     }
 
-    $parsed = $response.Content | ConvertFrom-Json
-    $newEtag = $response.Headers["ETag"]
-    if ($newEtag -is [array]) { $newEtag = $newEtag[0] }
-    return [pscustomobject]@{
-        Status = "ok"
-        Sha    = $parsed.sha
-        Etag   = $newEtag
+    if ($response.Content -match 'tag:github\.com,2008:Grit::Commit/([a-fA-F0-9]{40})') {
+        return [pscustomobject]@{
+            Status = "ok"
+            Sha    = $Matches[1].ToLower()
+        }
     }
+
+    throw "Could not parse latest commit SHA from atom feed at $url."
 }
 
 if (-not (Test-Path $logDir)) {
@@ -286,7 +296,7 @@ try {
     $state = Read-StateOrBakLocal -Path $statePath
 
     # Ensure newer schema fields exist even when reading an older state file.
-    foreach ($field in @('lastSelfUpdateSha', 'lastEtag', 'backoffUntil', 'lastCheckAt')) {
+    foreach ($field in @('lastSelfUpdateSha', 'backoffUntil', 'lastCheckAt')) {
         if (-not ($state.PSObject.Properties.Name -contains $field)) {
             $state | Add-Member -NotePropertyName $field -NotePropertyValue $null -Force
         }
@@ -318,9 +328,7 @@ try {
 
     Write-UpdateLog "Checking $repoOwner/$repoName@$branch (purpose=$purpose, ownership=$ownership)."
 
-    # Send a conditional request. Only the first request (or after a real change)
-    # spends a unit of the unauthenticated rate-limit budget; 304s are free.
-    $check = Invoke-GitHubApiCommitCheck -Owner $repoOwner -Repo $repoName -Branch $branch -Etag $state.lastEtag
+    $check = Invoke-AtomBranchCheck -Owner $repoOwner -Repo $repoName -Branch $branch
 
     $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
@@ -328,48 +336,24 @@ try {
         $state.backoffUntil = $check.BackoffUntil.ToString("yyyy-MM-ddTHH:mm:ssZ")
         $state.lastCheckAt = $now
         Save-StateAtomicLocal -Path $statePath -State $state
-        Write-UpdateLog "GitHub API returned $($check.StatusCode); backoff until $($state.backoffUntil)." "WARN"
+        Write-UpdateLog "github.com returned $($check.StatusCode); backoff until $($state.backoffUntil)." "WARN"
         return
     }
 
-    # Clear any stale backoff now that the API is answering normally again.
+    # Clear any stale backoff now that github.com is answering normally again.
     $state.backoffUntil = $null
     $state.lastCheckAt = $now
 
-    if ($check.Status -eq "notModified") {
-        # Server confirms our cached version is current. Use the SHA we last applied
-        # as the target so we can still retry a stalled self-copy from this run.
-        $remoteSha = $state.lastAppliedSha
-        if (-not $remoteSha) {
-            # We have an ETag but no recorded SHA (unusual). Force a fresh request
-            # next tick by dropping the ETag.
-            $state.lastEtag = $null
-            Save-StateAtomicLocal -Path $statePath -State $state
-            Write-UpdateLog "304 received but no lastAppliedSha; cleared ETag, will fetch full payload next tick." "WARN"
-            return
-        }
-        Write-UpdateLog "API returned 304 (no change); target SHA $remoteSha."
-        $pendingEtag = $state.lastEtag
-    }
-    else {
-        $remoteSha = $check.Sha
-        if (-not $remoteSha) {
-            Write-UpdateLog "GitHub API response did not include a SHA; aborting." "ERROR"
-            return
-        }
-        # The new ETag goes into state ONLY after a successful apply below; if we
-        # crash between here and there, the next tick will re-fetch the same SHA.
-        $pendingEtag = $check.Etag
+    $remoteSha = $check.Sha
+    if (-not $remoteSha) {
+        Write-UpdateLog "Atom feed did not contain a SHA; aborting." "ERROR"
+        return
     }
 
     $policyCurrent = $state.lastAppliedSha -eq $remoteSha
     $selfCurrent = $state.lastSelfUpdateSha -eq $remoteSha
 
     if ($policyCurrent -and $selfCurrent) {
-        # Fully caught up. Persist lastCheckAt (and, on a fresh 200, the new ETag).
-        if ($check.Status -eq "ok") {
-            $state.lastEtag = $pendingEtag
-        }
         Save-StateAtomicLocal -Path $statePath -State $state
         Write-UpdateLog "Already at $remoteSha; nothing to do."
         return
@@ -468,9 +452,6 @@ try {
             # there does not force a re-apply on the next tick.
             $state.lastAppliedSha = $remoteSha
             $state.lastAppliedAt = $now
-            if ($check.Status -eq "ok") {
-                $state.lastEtag = $pendingEtag
-            }
             Save-StateAtomicLocal -Path $statePath -State $state
             Write-UpdateLog "Applied policy SHA $remoteSha."
         }
@@ -496,9 +477,6 @@ try {
             try {
                 Copy-Item -Path $newSelf -Destination $selfPath -Force
                 $state.lastSelfUpdateSha = $remoteSha
-                if ($check.Status -eq "ok") {
-                    $state.lastEtag = $pendingEtag
-                }
                 Save-StateAtomicLocal -Path $statePath -State $state
                 Write-UpdateLog "Auto-updater payload refreshed at $selfPath."
             }

--- a/scripts/policies.ps1
+++ b/scripts/policies.ps1
@@ -26,7 +26,6 @@ $ErrorActionPreference = "Stop"
     The ownership type: "shared", "personal", or "dedicated"
 #>
 
-# Paths
 $deployPath = Get-DeployPath
 $lgpoPath = Join-DeployPath "bin\LGPO.exe"
 $policiesPath = Join-DeployPath "policies"
@@ -63,7 +62,6 @@ function Get-ApplicablePolicies {
             $fullPath = Join-Path $policiesPath $policyPath
 
             if (Test-Path $fullPath) {
-                # Determine if Computer or User policy by reading first line
                 $firstLine = Get-Content $fullPath -First 1
                 if ($firstLine -eq "Computer") {
                     $applicable.Computer += $fullPath
@@ -104,12 +102,10 @@ function Set-Policy {
         [hashtable]$policies
     )
 
-    # Create temp directory
     if (-not (Test-Path $tempPath)) {
         New-Item -ItemType Directory -Path $tempPath -Force | Out-Null
     }
 
-    # Process Computer policies
     if ($policies.Computer.Count -gt 0 -and $PSCmdlet.ShouldProcess("Computer local policy", "Apply $($policies.Computer.Count) policies")) {
         Write-Output "`nApplying $($policies.Computer.Count) computer policies..."
 
@@ -129,7 +125,6 @@ function Set-Policy {
         Write-Output "  Computer policies applied successfully"
     }
 
-    # Process User policies
     if ($policies.User.Count -gt 0 -and $PSCmdlet.ShouldProcess("Non-admin user local policy", "Apply $($policies.User.Count) policies")) {
         Write-Output "`nApplying $($policies.User.Count) user policies (non-admin accounts)..."
 
@@ -149,15 +144,12 @@ function Set-Policy {
         Write-Output "  User policies applied successfully"
     }
 
-    # Cleanup temp files
     Remove-Item -Path $tempPath -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-# Main execution
 Write-Output "=== Windows 11 Policy Application ==="
 Write-Output ""
 
-# Validate parameters (install.ps1 already validates values, just check presence)
 if (-not $systemPurpose -or -not $systemOwnership) {
     throw "Both 'systemPurpose' and 'systemOwnership' parameters must be provided."
 }
@@ -165,10 +157,8 @@ if (-not $systemPurpose -or -not $systemOwnership) {
 $systemPurpose = $systemPurpose.ToLower()
 $systemOwnership = $systemOwnership.ToLower()
 
-# Verify LGPO.exe is present and matches the SHA-256 in bin/hashes.json.
 Assert-BundledBinary -BinaryPath $lgpoPath
 
-# Verify config exists
 if (-not (Test-Path $configPath)) {
     throw "Policy configuration not found at $configPath"
 }
@@ -177,7 +167,6 @@ Write-Output "Purpose: $systemPurpose"
 Write-Output "Ownership: $systemOwnership"
 Write-Output ""
 
-# Download wallpaper for shared and personal systems
 if ($systemOwnership -eq "shared" -or $systemOwnership -eq "personal") {
     $wallpaperUrl = "https://www.zuidwestupdate.nl/wp-content/uploads/2021/03/voorpagina-placeholder.png"
     $wallpaperDir = Join-ZuidWestPath "wallpaper"
@@ -199,10 +188,8 @@ if ($systemOwnership -eq "shared" -or $systemOwnership -eq "personal") {
 
 Write-Output "Finding applicable policies..."
 
-# Load configuration
 $config = Get-Content $configPath -Raw | ConvertFrom-Json
 
-# Get applicable policies
 $applicablePolicies = Get-ApplicablePolicies -config $config -purpose $systemPurpose -ownership $systemOwnership
 
 $totalPolicies = $applicablePolicies.Computer.Count + $applicablePolicies.User.Count
@@ -214,7 +201,6 @@ if ($totalPolicies -eq 0) {
 
 Write-Output "`nFound $totalPolicies applicable policies"
 
-# Apply policies
 Set-Policy -policies $applicablePolicies
 
 Write-Output "`n=== Policy application complete ==="

--- a/scripts/policies.ps1
+++ b/scripts/policies.ps1
@@ -178,7 +178,7 @@ Write-Output ""
 # Download wallpaper for shared and personal systems
 if ($systemOwnership -eq "shared" -or $systemOwnership -eq "personal") {
     $wallpaperUrl = "https://www.zuidwestupdate.nl/wp-content/uploads/2021/03/voorpagina-placeholder.png"
-    $wallpaperDir = "C:\ProgramData\ZuidWest\wallpaper"
+    $wallpaperDir = Join-ZuidWestPath "wallpaper"
     $wallpaperPath = Join-Path $wallpaperDir "wallpaper.png"
 
     Write-Output "Downloading wallpaper..."

--- a/scripts/policies.ps1
+++ b/scripts/policies.ps1
@@ -3,6 +3,8 @@ param (
     [string]$systemOwnership
 )
 
+$ErrorActionPreference = "Stop"
+
 . (Join-Path $PSScriptRoot "_common.ps1")
 
 <#

--- a/scripts/policies.ps1
+++ b/scripts/policies.ps1
@@ -163,10 +163,8 @@ if (-not $systemPurpose -or -not $systemOwnership) {
 $systemPurpose = $systemPurpose.ToLower()
 $systemOwnership = $systemOwnership.ToLower()
 
-# Verify LGPO.exe exists
-if (-not (Test-Path $lgpoPath)) {
-    throw "LGPO.exe not found at $lgpoPath"
-}
+# Verify LGPO.exe is present and matches the SHA-256 in bin/hashes.json.
+Assert-BundledBinary -BinaryPath $lgpoPath
 
 # Verify config exists
 if (-not (Test-Path $configPath)) {

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -23,7 +23,12 @@ param (
 
     Scheduled Task: \ZuidWest\PolicyAutoUpdate
       - Runs as SYSTEM at: system startup, any user logon, hourly
-      - Only ever consults the GitHub API; downloads only when SHA changed
+      - The hourly trigger uses a per-install random minute offset stored in
+        state.pollOffsetMinutes so a fleet behind one NAT spreads the
+        unauthenticated GitHub API checks across the hour instead of all
+        firing in lockstep.
+      - The updater itself uses conditional ETag requests, so steady-state
+        polling does not burn rate-limit quota.
 
     Re-running this script (via install.ps1 -OnlyRun policyupdate) refreshes
     state.json with the current purpose/ownership and reinstalls the payload
@@ -64,24 +69,27 @@ if (-not (Test-Path $persistentRoot)) {
 # fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
 # next tick.
 $state = [ordered]@{
-    schemaVersion     = 1
+    schemaVersion     = 2
     repoOwner         = "oszuidwest"
     repoName          = "windows11-baseline"
     branch            = "main"
     systemPurpose     = $systemPurpose.ToLower()
     systemOwnership   = $systemOwnership.ToLower()
     scriptsToReapply  = @("policies", "applocker")
+    pollOffsetMinutes = Get-Random -Minimum 0 -Maximum 60
     lastAppliedSha    = $null
     lastAppliedAt     = $null
     lastSelfUpdateSha = $null
+    lastEtag          = $null
     lastCheckAt       = $null
+    backoffUntil      = $null
 }
 
 if (Test-Path $statePath) {
     try {
         $previous = Read-DeploymentState -Path $statePath
-        foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastCheckAt")) {
-            if ($previous.PSObject.Properties.Name -contains $key) {
+        foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastEtag", "lastCheckAt", "backoffUntil", "pollOffsetMinutes")) {
+            if ($previous.PSObject.Properties.Name -contains $key -and $null -ne $previous.$key) {
                 $state[$key] = $previous.$key
             }
         }
@@ -97,6 +105,7 @@ Write-Output "  Purpose:    $($state.systemPurpose)"
 Write-Output "  Ownership:  $($state.systemOwnership)"
 Write-Output "  Repo:       $($state.repoOwner)/$($state.repoName)@$($state.branch)"
 Write-Output "  Re-apply:   $($state.scriptsToReapply -join ', ')"
+Write-Output "  Poll offset:$($state.pollOffsetMinutes) min past the hour"
 
 Copy-Item -Path $payloadSource -Destination $updaterPath -Force
 Write-Output "Updater payload: $updaterPath"
@@ -109,11 +118,12 @@ $action = New-ScheduledTaskAction `
 $startupTrigger = New-ScheduledTaskTrigger -AtStartup
 $logonTrigger = New-ScheduledTaskTrigger -AtLogOn
 
-# Hourly: a -Once trigger anchored shortly after install, repeating every hour
-# for a far-future duration. Avoids the "midnight daily + sub-day repetition"
-# combo whose behaviour varies across Windows builds.
+# Hourly: a -Once trigger anchored shortly after install plus a per-install
+# random minute offset, repeating every hour for a far-future duration. The
+# offset spreads the fleet's polling across the hour so a small office NAT
+# does not burn the unauthenticated GitHub API budget at xx:00 every hour.
 $hourlyTrigger = New-ScheduledTaskTrigger `
-    -Once -At (Get-Date).AddMinutes(5) `
+    -Once -At (Get-Date).AddMinutes(5 + $state.pollOffsetMinutes) `
     -RepetitionInterval (New-TimeSpan -Hours 1) `
     -RepetitionDuration (New-TimeSpan -Days 365000)
 
@@ -134,13 +144,13 @@ $task = New-ScheduledTask `
     -Trigger @($startupTrigger, $logonTrigger, $hourlyTrigger) `
     -Principal $principal `
     -Settings $settings `
-    -Description "Streekomroep ZuidWest baseline policy auto-update. Polls GitHub for new commits on the configured branch and re-applies the policies + AppLocker layer when the SHA changes."
+    -Description "Streekomroep ZuidWest baseline policy auto-update. Polls GitHub (conditional requests, ETag cache, backoff on 403/429) for new commits on the configured branch and re-applies the policies + AppLocker layer when the SHA changes."
 
 Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $task -Force | Out-Null
 Write-Output "Scheduled Task registered: $taskFullPath"
 
 Write-Output ""
-Write-Output "Triggers: system startup, any user logon, hourly."
+Write-Output "Triggers: system startup, any user logon, hourly (offset +$($state.pollOffsetMinutes) min)."
 Write-Output "Logs:     $(Join-Path $env:ProgramData 'ZuidWest\Logs\policy-auto-update.log')"
 Write-Output ""
 Write-Output "=== Policy Auto-Update Installation complete ==="

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -27,8 +27,9 @@ param (
         fire is jittered 0-60 minutes after its anchor. A fleet behind one
         NAT spreads its GitHub checks across the hour rather than all firing
         in lockstep.
-      - The updater uses conditional ETag requests, which always saves
-        bandwidth and may also reduce rate-limit pressure (see the payload).
+      - The updater asks github.com's commits.atom feed (not api.github.com)
+        for the current branch HEAD SHA, so the check does not consume the
+        unauthenticated REST API budget at all.
 
     Re-running this script (via install.ps1 -OnlyRun policyupdate) refreshes
     state.json with the current purpose/ownership and reinstalls the payload
@@ -71,7 +72,7 @@ if (-not (Test-Path $persistentRoot)) {
 # fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
 # next tick.
 $state = [ordered]@{
-    schemaVersion     = 3
+    schemaVersion     = 4
     repoOwner         = "oszuidwest"
     repoName          = "windows11-baseline"
     branch            = "main"
@@ -81,7 +82,6 @@ $state = [ordered]@{
     lastAppliedSha    = $null
     lastAppliedAt     = $null
     lastSelfUpdateSha = $null
-    lastEtag          = $null
     lastCheckAt       = $null
     backoffUntil      = $null
 }
@@ -97,7 +97,7 @@ if (Test-Path $statePath) {
 }
 
 if ($previous) {
-    foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastEtag", "lastCheckAt", "backoffUntil")) {
+    foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastCheckAt", "backoffUntil")) {
         if ($previous.PSObject.Properties.Name -contains $key -and $null -ne $previous.$key) {
             $state[$key] = $previous.$key
         }
@@ -132,7 +132,6 @@ if ($contextChanged) {
     $state.lastAppliedSha = $null
     $state.lastAppliedAt = $null
     $state.lastSelfUpdateSha = $null
-    $state.lastEtag = $null
     $state.backoffUntil = $null
     Write-Output "Deployment context changed since previous install; cleared applied-SHA tracking. Next auto-update tick will reapply."
 }
@@ -181,7 +180,7 @@ $task = New-ScheduledTask `
     -Trigger @($startupTrigger, $logonTrigger, $hourlyTrigger) `
     -Principal $principal `
     -Settings $settings `
-    -Description "Streekomroep ZuidWest baseline policy auto-update. Polls GitHub (conditional requests, ETag cache, backoff on 403/429) for new commits on the configured branch and re-applies the policies + AppLocker layer when the SHA changes."
+    -Description "Streekomroep ZuidWest baseline policy auto-update. Polls github.com's commits.atom feed (not the REST API) for new commits on the configured branch and re-applies the policies + AppLocker layer when the SHA changes."
 
 Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $task -Force | Out-Null
 Write-Output "Scheduled Task registered: $taskFullPath"

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -32,8 +32,10 @@ param (
 
     Re-running this script (via install.ps1 -OnlyRun policyupdate) refreshes
     state.json with the current purpose/ownership and reinstalls the payload
-    + task definition. The previously applied SHA is preserved so the next
-    auto-update tick is still a no-op if nothing in main has moved.
+    + task definition. If any context field (purpose, ownership, repo, branch,
+    scriptsToReapply) actually changed, the recorded lastAppliedSha and
+    lastSelfUpdateSha are cleared so the next auto-update tick re-applies
+    against the new context even when main has not moved.
 
 .PARAMETER systemPurpose
     The purpose of the system: "radio", "tv", "editorial", or "plain".
@@ -85,18 +87,55 @@ $state = [ordered]@{
     backoffUntil      = $null
 }
 
+$previous = $null
 if (Test-Path $statePath) {
     try {
         $previous = Read-DeploymentState -Path $statePath
-        foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastEtag", "lastCheckAt", "backoffUntil", "pollOffsetMinutes")) {
-            if ($previous.PSObject.Properties.Name -contains $key -and $null -ne $previous.$key) {
-                $state[$key] = $previous.$key
-            }
-        }
     }
     catch {
         Write-Warning "Could not read existing state file ($_); starting fresh."
     }
+}
+
+if ($previous) {
+    foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastEtag", "lastCheckAt", "backoffUntil", "pollOffsetMinutes")) {
+        if ($previous.PSObject.Properties.Name -contains $key -and $null -ne $previous.$key) {
+            $state[$key] = $previous.$key
+        }
+    }
+}
+
+# Detect a context change: if any of the inputs that drive what gets applied
+# changed since the previous deployment, null out the applied-SHA tracking so
+# the next auto-update tick reapplies against the new context. Without this,
+# an operator running -OnlyRun policyupdate to switch purpose/ownership would
+# update state.json but the updater would short-circuit until main advances.
+$contextChanged = $false
+if ($previous) {
+    $contextKeys = @('systemPurpose', 'systemOwnership', 'branch', 'repoOwner', 'repoName', 'scriptsToReapply')
+    foreach ($key in $contextKeys) {
+        $oldValue = $previous.$key
+        $newValue = $state[$key]
+        if ($oldValue -is [array] -or $newValue -is [array]) {
+            $same = $null -eq (Compare-Object @($oldValue) @($newValue))
+        }
+        else {
+            $same = ($oldValue -eq $newValue)
+        }
+        if (-not $same) {
+            $contextChanged = $true
+            break
+        }
+    }
+}
+
+if ($contextChanged) {
+    $state.lastAppliedSha = $null
+    $state.lastAppliedAt = $null
+    $state.lastSelfUpdateSha = $null
+    $state.lastEtag = $null
+    $state.backoffUntil = $null
+    Write-Output "Deployment context changed since previous install; cleared applied-SHA tracking. Next auto-update tick will reapply."
 }
 
 Save-DeploymentStateAtomic -Path $statePath -State $state

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -23,10 +23,10 @@ param (
 
     Scheduled Task: \ZuidWest\PolicyAutoUpdate
       - Runs as SYSTEM at: system startup, any user logon, hourly
-      - The hourly trigger uses New-ScheduledTaskTrigger -RandomDelay so each
-        fire is jittered 0-60 minutes after its anchor. A fleet behind one
-        NAT spreads its GitHub checks across the hour rather than all firing
-        in lockstep.
+      - Every trigger (startup, logon, hourly) carries -RandomDelay so the
+        fleet does not poll in lockstep after a maintenance reboot, a
+        morning logon rush, or on the hour. Windows are 15 min, 5 min, and
+        60 min respectively.
       - The updater asks github.com's commits.atom feed (not api.github.com)
         for the current branch HEAD SHA, so the check does not consume the
         unauthenticated REST API budget at all.
@@ -151,12 +151,15 @@ $action = New-ScheduledTaskAction `
     -Execute "PowerShell.exe" `
     -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$updaterPath`""
 
-$startupTrigger = New-ScheduledTaskTrigger -AtStartup
-$logonTrigger = New-ScheduledTaskTrigger -AtLogOn
+# Every trigger jitters with -RandomDelay so the fleet does not poll in
+# lockstep. Without this, a post-maintenance reboot fleet-wide or a 09:00
+# logon rush would land all checks on github.com within the same minute.
+$startupTrigger = New-ScheduledTaskTrigger -AtStartup `
+    -RandomDelay (New-TimeSpan -Minutes 15)
 
-# Hourly: a -Once trigger anchored five minutes after install, repeating every
-# hour for a far-future duration. -RandomDelay adds 0-60 minutes of jitter to
-# each fire so a fleet behind one NAT does not all hit GitHub at xx:05.
+$logonTrigger = New-ScheduledTaskTrigger -AtLogOn `
+    -RandomDelay (New-TimeSpan -Minutes 5)
+
 $hourlyTrigger = New-ScheduledTaskTrigger `
     -Once -At (Get-Date).AddMinutes(5) `
     -RandomDelay (New-TimeSpan -Minutes 60) `
@@ -186,7 +189,7 @@ Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $t
 Write-Output "Scheduled Task registered: $taskFullPath"
 
 Write-Output ""
-Write-Output "Triggers: system startup, any user logon, hourly with 0-60 min random delay."
+Write-Output "Triggers: startup (jitter 15 min), logon (jitter 5 min), hourly (jitter 60 min)."
 Write-Output "Logs:     $(Join-Path $env:ProgramData 'ZuidWest\Logs\policy-auto-update.log')"
 Write-Output ""
 Write-Output "=== Policy Auto-Update Installation complete ==="

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -64,22 +64,23 @@ if (-not (Test-Path $persistentRoot)) {
 # fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
 # next tick.
 $state = [ordered]@{
-    schemaVersion    = 1
-    repoOwner        = "oszuidwest"
-    repoName         = "windows11-baseline"
-    branch           = "main"
-    systemPurpose    = $systemPurpose.ToLower()
-    systemOwnership  = $systemOwnership.ToLower()
-    scriptsToReapply = @("policies", "applocker")
-    lastAppliedSha   = $null
-    lastAppliedAt    = $null
-    lastCheckAt      = $null
+    schemaVersion     = 1
+    repoOwner         = "oszuidwest"
+    repoName          = "windows11-baseline"
+    branch            = "main"
+    systemPurpose     = $systemPurpose.ToLower()
+    systemOwnership   = $systemOwnership.ToLower()
+    scriptsToReapply  = @("policies", "applocker")
+    lastAppliedSha    = $null
+    lastAppliedAt     = $null
+    lastSelfUpdateSha = $null
+    lastCheckAt       = $null
 }
 
 if (Test-Path $statePath) {
     try {
         $previous = Read-DeploymentState -Path $statePath
-        foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastCheckAt")) {
+        foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastCheckAt")) {
             if ($previous.PSObject.Properties.Name -contains $key) {
                 $state[$key] = $previous.$key
             }

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -77,9 +77,7 @@ if (-not (Test-Path $persistentRoot)) {
     New-Item -Path $persistentRoot -ItemType Directory -Force | Out-Null
 }
 
-# Build the new state. Preserve the previously applied SHA across re-runs so a
-# fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
-# next tick.
+# Preserve applied SHAs across task refreshes to avoid redundant re-apply.
 $state = [ordered]@{
     schemaVersion     = 5
     enabled           = $true
@@ -114,11 +112,7 @@ if ($previous) {
     }
 }
 
-# Detect a context change: if any of the inputs that drive what gets applied
-# changed since the previous deployment, null out the applied-SHA tracking so
-# the next auto-update tick reapplies against the new context. Without this,
-# an operator running -OnlyRun policyupdate to switch purpose/ownership would
-# update state.json but the updater would short-circuit until main advances.
+# Context changes must force a re-apply even if main has not advanced.
 $contextChanged = $false
 if ($previous) {
     $contextKeys = @('systemPurpose', 'systemOwnership', 'branch', 'repoOwner', 'repoName', 'scriptsToReapply')
@@ -169,14 +163,11 @@ Write-Output "  Re-apply:   $($state.scriptsToReapply -join ', ')"
 Copy-Item -Path $payloadSource -Destination $updaterPath -Force -ErrorAction Stop
 Write-Output "Updater payload: $updaterPath"
 
-# Register / refresh the Scheduled Task.
 $action = New-ScheduledTaskAction `
     -Execute "PowerShell.exe" `
     -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$updaterPath`""
 
-# Every trigger jitters with -RandomDelay so the fleet does not poll in
-# lockstep. Without this, a post-maintenance reboot fleet-wide or a 09:00
-# logon rush would land all checks on github.com within the same minute.
+# Jitter prevents fleet-wide boot/logon bursts against github.com.
 $startupTrigger = New-ScheduledTaskTrigger -AtStartup `
     -RandomDelay (New-TimeSpan -Minutes 15)
 

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -1,0 +1,144 @@
+param (
+    [string]$systemPurpose,
+    [string]$systemOwnership
+)
+
+. (Join-Path $PSScriptRoot "_common.ps1")
+
+<#
+.SYNOPSIS
+    Installs the periodic-and-at-logon policy auto-update mechanism.
+
+.DESCRIPTION
+    Persists deployment state, deploys the auto-updater payload to a stable
+    location outside C:\Windows\deploy, and registers a Scheduled Task that
+    re-applies the policy + AppLocker layers whenever the configured GitHub
+    branch advances.
+
+    Persistent files (under C:\ProgramData\ZuidWest\policy-update\):
+      - state.json        Deployment context, repo coordinates, last SHA
+      - update.ps1        Copy of scripts/lib/policy-auto-updater.ps1
+      - staging/          Created/destroyed per run (download workspace)
+
+    Scheduled Task: \ZuidWest\PolicyAutoUpdate
+      - Runs as SYSTEM at: system startup, any user logon, hourly
+      - Only ever consults the GitHub API; downloads only when SHA changed
+
+    Re-running this script (via install.ps1 -OnlyRun policyupdate) refreshes
+    state.json with the current purpose/ownership and reinstalls the payload
+    + task definition. The previously applied SHA is preserved so the next
+    auto-update tick is still a no-op if nothing in main has moved.
+
+.PARAMETER systemPurpose
+    The purpose of the system: "radio", "tv", "editorial", or "plain".
+
+.PARAMETER systemOwnership
+    The ownership type: "shared", "personal", or "dedicated".
+#>
+
+if (-not $systemPurpose -or -not $systemOwnership) {
+    throw "Both 'systemPurpose' and 'systemOwnership' parameters must be provided."
+}
+
+$persistentRoot = Join-Path $env:ProgramData "ZuidWest\policy-update"
+$statePath = Join-Path $persistentRoot "state.json"
+$updaterPath = Join-Path $persistentRoot "update.ps1"
+$payloadSource = Join-Path $PSScriptRoot "lib\policy-auto-updater.ps1"
+$taskFolder = "\ZuidWest"
+$taskName = "PolicyAutoUpdate"
+$taskFullPath = "$taskFolder\$taskName"
+
+Write-Output "=== Policy Auto-Update Installation ==="
+Write-Output ""
+
+if (-not (Test-Path $payloadSource)) {
+    throw "Auto-updater payload not found at $payloadSource"
+}
+
+if (-not (Test-Path $persistentRoot)) {
+    New-Item -Path $persistentRoot -ItemType Directory -Force | Out-Null
+}
+
+# Build the new state. Preserve the previously applied SHA across re-runs so a
+# fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
+# next tick.
+$state = [ordered]@{
+    schemaVersion    = 1
+    repoOwner        = "oszuidwest"
+    repoName         = "windows11-baseline"
+    branch           = "main"
+    systemPurpose    = $systemPurpose.ToLower()
+    systemOwnership  = $systemOwnership.ToLower()
+    scriptsToReapply = @("policies", "applocker")
+    lastAppliedSha   = $null
+    lastAppliedAt    = $null
+    lastCheckAt      = $null
+}
+
+if (Test-Path $statePath) {
+    try {
+        $previous = Get-Content -Path $statePath -Raw | ConvertFrom-Json
+        foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastCheckAt")) {
+            if ($previous.PSObject.Properties.Name -contains $key) {
+                $state[$key] = $previous.$key
+            }
+        }
+    }
+    catch {
+        Write-Warning "Could not read existing state file ($_); starting fresh."
+    }
+}
+
+$state | ConvertTo-Json -Depth 4 | Set-Content -Path $statePath -Encoding UTF8
+Write-Output "Deployment state: $statePath"
+Write-Output "  Purpose:    $($state.systemPurpose)"
+Write-Output "  Ownership:  $($state.systemOwnership)"
+Write-Output "  Repo:       $($state.repoOwner)/$($state.repoName)@$($state.branch)"
+Write-Output "  Re-apply:   $($state.scriptsToReapply -join ', ')"
+
+Copy-Item -Path $payloadSource -Destination $updaterPath -Force
+Write-Output "Updater payload: $updaterPath"
+
+# Register / refresh the Scheduled Task.
+$action = New-ScheduledTaskAction `
+    -Execute "PowerShell.exe" `
+    -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$updaterPath`""
+
+$startupTrigger = New-ScheduledTaskTrigger -AtStartup
+$logonTrigger = New-ScheduledTaskTrigger -AtLogOn
+
+# Hourly: a -Once trigger anchored shortly after install, repeating every hour
+# for a far-future duration. Avoids the "midnight daily + sub-day repetition"
+# combo whose behaviour varies across Windows builds.
+$hourlyTrigger = New-ScheduledTaskTrigger `
+    -Once -At (Get-Date).AddMinutes(5) `
+    -RepetitionInterval (New-TimeSpan -Hours 1) `
+    -RepetitionDuration (New-TimeSpan -Days 365000)
+
+$principal = New-ScheduledTaskPrincipal `
+    -UserId "SYSTEM" `
+    -LogonType ServiceAccount `
+    -RunLevel Highest
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 30)
+
+$task = New-ScheduledTask `
+    -Action $action `
+    -Trigger @($startupTrigger, $logonTrigger, $hourlyTrigger) `
+    -Principal $principal `
+    -Settings $settings `
+    -Description "Streekomroep ZuidWest baseline policy auto-update. Polls GitHub for new commits on the configured branch and re-applies the policies + AppLocker layer when the SHA changes."
+
+Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $task -Force | Out-Null
+Write-Output "Scheduled Task registered: $taskFullPath"
+
+Write-Output ""
+Write-Output "Triggers: system startup, any user logon, hourly."
+Write-Output "Logs:     $(Join-Path $env:ProgramData 'ZuidWest\Logs\policy-auto-update.log')"
+Write-Output ""
+Write-Output "=== Policy Auto-Update Installation complete ==="

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -11,9 +11,9 @@ param (
 
 .DESCRIPTION
     Persists deployment state, deploys the auto-updater payload to a stable
-    location outside C:\Windows\deploy, and registers a Scheduled Task that
-    re-applies the policy + AppLocker layers whenever the configured GitHub
-    branch advances.
+    runtime location under C:\ProgramData\ZuidWest, and registers a Scheduled
+    Task that re-applies the policy + AppLocker layers whenever the configured
+    GitHub branch advances.
 
     Persistent files (under C:\ProgramData\ZuidWest\policy-update\):
       - state.json        Deployment context, repo coordinates, last SHA
@@ -49,7 +49,7 @@ if (-not $systemPurpose -or -not $systemOwnership) {
     throw "Both 'systemPurpose' and 'systemOwnership' parameters must be provided."
 }
 
-$persistentRoot = Join-Path $env:ProgramData "ZuidWest\policy-update"
+$persistentRoot = Join-ZuidWestPath "policy-update"
 $statePath = Join-Path $persistentRoot "state.json"
 $updaterPath = Join-Path $persistentRoot "update.ps1"
 $payloadSource = Join-Path $PSScriptRoot "lib\policy-auto-updater.ps1"
@@ -190,6 +190,6 @@ Write-Output "Scheduled Task registered: $taskFullPath"
 
 Write-Output ""
 Write-Output "Triggers: startup (jitter 15 min), logon (jitter 5 min), hourly (jitter 60 min)."
-Write-Output "Logs:     $(Join-Path $env:ProgramData 'ZuidWest\Logs\policy-auto-update.log')"
+Write-Output "Logs:     $(Join-ZuidWestPath 'Logs', 'policy-auto-update.log')"
 Write-Output ""
 Write-Output "=== Policy Auto-Update Installation complete ==="

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -17,6 +17,7 @@ param (
 
     Persistent files (under C:\ProgramData\ZuidWest\policy-update\):
       - state.json        Deployment context, repo coordinates, last SHA
+      - state.json.bak    Previous generation, kept by Save-DeploymentStateAtomic
       - update.ps1        Copy of scripts/lib/policy-auto-updater.ps1
       - staging/          Created/destroyed per run (download workspace)
 
@@ -77,7 +78,7 @@ $state = [ordered]@{
 
 if (Test-Path $statePath) {
     try {
-        $previous = Get-Content -Path $statePath -Raw | ConvertFrom-Json
+        $previous = Read-DeploymentState -Path $statePath
         foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastCheckAt")) {
             if ($previous.PSObject.Properties.Name -contains $key) {
                 $state[$key] = $previous.$key
@@ -89,7 +90,7 @@ if (Test-Path $statePath) {
     }
 }
 
-$state | ConvertTo-Json -Depth 4 | Set-Content -Path $statePath -Encoding UTF8
+Save-DeploymentStateAtomic -Path $statePath -State $state
 Write-Output "Deployment state: $statePath"
 Write-Output "  Purpose:    $($state.systemPurpose)"
 Write-Output "  Ownership:  $($state.systemOwnership)"

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -23,12 +23,12 @@ param (
 
     Scheduled Task: \ZuidWest\PolicyAutoUpdate
       - Runs as SYSTEM at: system startup, any user logon, hourly
-      - The hourly trigger uses a per-install random minute offset stored in
-        state.pollOffsetMinutes so a fleet behind one NAT spreads the
-        unauthenticated GitHub API checks across the hour instead of all
-        firing in lockstep.
-      - The updater itself uses conditional ETag requests, so steady-state
-        polling does not burn rate-limit quota.
+      - The hourly trigger uses New-ScheduledTaskTrigger -RandomDelay so each
+        fire is jittered 0-60 minutes after its anchor. A fleet behind one
+        NAT spreads its GitHub checks across the hour rather than all firing
+        in lockstep.
+      - The updater uses conditional ETag requests, which always saves
+        bandwidth and may also reduce rate-limit pressure (see the payload).
 
     Re-running this script (via install.ps1 -OnlyRun policyupdate) refreshes
     state.json with the current purpose/ownership and reinstalls the payload
@@ -71,14 +71,13 @@ if (-not (Test-Path $persistentRoot)) {
 # fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
 # next tick.
 $state = [ordered]@{
-    schemaVersion     = 2
+    schemaVersion     = 3
     repoOwner         = "oszuidwest"
     repoName          = "windows11-baseline"
     branch            = "main"
     systemPurpose     = $systemPurpose.ToLower()
     systemOwnership   = $systemOwnership.ToLower()
     scriptsToReapply  = @("policies", "applocker")
-    pollOffsetMinutes = Get-Random -Minimum 0 -Maximum 60
     lastAppliedSha    = $null
     lastAppliedAt     = $null
     lastSelfUpdateSha = $null
@@ -98,7 +97,7 @@ if (Test-Path $statePath) {
 }
 
 if ($previous) {
-    foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastEtag", "lastCheckAt", "backoffUntil", "pollOffsetMinutes")) {
+    foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastEtag", "lastCheckAt", "backoffUntil")) {
         if ($previous.PSObject.Properties.Name -contains $key -and $null -ne $previous.$key) {
             $state[$key] = $previous.$key
         }
@@ -144,7 +143,6 @@ Write-Output "  Purpose:    $($state.systemPurpose)"
 Write-Output "  Ownership:  $($state.systemOwnership)"
 Write-Output "  Repo:       $($state.repoOwner)/$($state.repoName)@$($state.branch)"
 Write-Output "  Re-apply:   $($state.scriptsToReapply -join ', ')"
-Write-Output "  Poll offset:$($state.pollOffsetMinutes) min past the hour"
 
 Copy-Item -Path $payloadSource -Destination $updaterPath -Force
 Write-Output "Updater payload: $updaterPath"
@@ -157,12 +155,12 @@ $action = New-ScheduledTaskAction `
 $startupTrigger = New-ScheduledTaskTrigger -AtStartup
 $logonTrigger = New-ScheduledTaskTrigger -AtLogOn
 
-# Hourly: a -Once trigger anchored shortly after install plus a per-install
-# random minute offset, repeating every hour for a far-future duration. The
-# offset spreads the fleet's polling across the hour so a small office NAT
-# does not burn the unauthenticated GitHub API budget at xx:00 every hour.
+# Hourly: a -Once trigger anchored five minutes after install, repeating every
+# hour for a far-future duration. -RandomDelay adds 0-60 minutes of jitter to
+# each fire so a fleet behind one NAT does not all hit GitHub at xx:05.
 $hourlyTrigger = New-ScheduledTaskTrigger `
-    -Once -At (Get-Date).AddMinutes(5 + $state.pollOffsetMinutes) `
+    -Once -At (Get-Date).AddMinutes(5) `
+    -RandomDelay (New-TimeSpan -Minutes 60) `
     -RepetitionInterval (New-TimeSpan -Hours 1) `
     -RepetitionDuration (New-TimeSpan -Days 365000)
 
@@ -189,7 +187,7 @@ Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $t
 Write-Output "Scheduled Task registered: $taskFullPath"
 
 Write-Output ""
-Write-Output "Triggers: system startup, any user logon, hourly (offset +$($state.pollOffsetMinutes) min)."
+Write-Output "Triggers: system startup, any user logon, hourly with 0-60 min random delay."
 Write-Output "Logs:     $(Join-Path $env:ProgramData 'ZuidWest\Logs\policy-auto-update.log')"
 Write-Output ""
 Write-Output "=== Policy Auto-Update Installation complete ==="

--- a/scripts/policyupdate.ps1
+++ b/scripts/policyupdate.ps1
@@ -1,7 +1,11 @@
 param (
     [string]$systemPurpose,
-    [string]$systemOwnership
+    [string]$systemOwnership,
+    [string]$installedSha,
+    [bool]$seedInstalledSha
 )
+
+$ErrorActionPreference = "Stop"
 
 . (Join-Path $PSScriptRoot "_common.ps1")
 
@@ -38,6 +42,11 @@ param (
     lastSelfUpdateSha are cleared so the next auto-update tick re-applies
     against the new context even when main has not moved.
 
+    Full installs pass the exact commit SHA that install.ps1 downloaded and
+    applied. In that case the state is seeded with that SHA to avoid a redundant
+    first scheduled-task apply. -OnlyRun policyupdate does not seed unless the
+    installer also ran policies and applocker in the same invocation.
+
 .PARAMETER systemPurpose
     The purpose of the system: "radio", "tv", "editorial", or "plain".
 
@@ -72,7 +81,8 @@ if (-not (Test-Path $persistentRoot)) {
 # fresh -OnlyRun policyupdate does not force a redundant policy reapply on the
 # next tick.
 $state = [ordered]@{
-    schemaVersion     = 4
+    schemaVersion     = 5
+    enabled           = $true
     repoOwner         = "oszuidwest"
     repoName          = "windows11-baseline"
     branch            = "main"
@@ -97,7 +107,7 @@ if (Test-Path $statePath) {
 }
 
 if ($previous) {
-    foreach ($key in @("lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastCheckAt", "backoffUntil")) {
+    foreach ($key in @("enabled", "lastAppliedSha", "lastAppliedAt", "lastSelfUpdateSha", "lastCheckAt", "backoffUntil")) {
         if ($previous.PSObject.Properties.Name -contains $key -and $null -ne $previous.$key) {
             $state[$key] = $previous.$key
         }
@@ -136,14 +146,27 @@ if ($contextChanged) {
     Write-Output "Deployment context changed since previous install; cleared applied-SHA tracking. Next auto-update tick will reapply."
 }
 
+if ($seedInstalledSha) {
+    if (-not $installedSha -or $installedSha -notmatch '^[a-fA-F0-9]{40}$') {
+        throw "Cannot seed policy auto-update state: installedSha must be a 40-character commit SHA."
+    }
+
+    $seedSha = $installedSha.ToLower()
+    $state.lastAppliedSha = $seedSha
+    $state.lastAppliedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $state.lastSelfUpdateSha = $seedSha
+    Write-Output "Seeded applied SHA from installer download: $seedSha"
+}
+
 Save-DeploymentStateAtomic -Path $statePath -State $state
 Write-Output "Deployment state: $statePath"
+Write-Output "  Enabled:    $($state.enabled)"
 Write-Output "  Purpose:    $($state.systemPurpose)"
 Write-Output "  Ownership:  $($state.systemOwnership)"
 Write-Output "  Repo:       $($state.repoOwner)/$($state.repoName)@$($state.branch)"
 Write-Output "  Re-apply:   $($state.scriptsToReapply -join ', ')"
 
-Copy-Item -Path $payloadSource -Destination $updaterPath -Force
+Copy-Item -Path $payloadSource -Destination $updaterPath -Force -ErrorAction Stop
 Write-Output "Updater payload: $updaterPath"
 
 # Register / refresh the Scheduled Task.
@@ -185,7 +208,7 @@ $task = New-ScheduledTask `
     -Settings $settings `
     -Description "Streekomroep ZuidWest baseline policy auto-update. Polls github.com's commits.atom feed (not the REST API) for new commits on the configured branch and re-applies the policies + AppLocker layer when the SHA changes."
 
-Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $task -Force | Out-Null
+Register-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -InputObject $task -Force -ErrorAction Stop | Out-Null
 Write-Output "Scheduled Task registered: $taskFullPath"
 
 Write-Output ""

--- a/scripts/power.ps1
+++ b/scripts/power.ps1
@@ -56,16 +56,14 @@ if (-not $success) {
     Write-Warning "Some power settings may not have been applied."
 }
 
-# Disable NIC power management for AoIP reliability (radio, tv, dedicated)
+# Keep audio/video network links awake on production systems.
 if ($systemPurpose -in @("radio", "tv") -or $systemOwnership -eq "dedicated") {
     Write-Output "  Disabling NIC power management for AoIP..."
     Get-NetAdapter -Physical | ForEach-Object {
         $adapterName = $_.Name
 
-        # Disable adapter power saving
         Set-NetAdapterPowerManagement -Name $adapterName -WakeOnMagicPacket Disabled -WakeOnPattern Disabled -DeviceSleepOnDisconnect Disabled -ErrorAction SilentlyContinue
 
-        # Disable Energy Efficient Ethernet (prevents latency spikes)
         Set-NetAdapterAdvancedProperty -Name $adapterName -RegistryKeyword "*EEE" -RegistryValue 0 -ErrorAction SilentlyContinue
 
         Write-Output "    $adapterName configured"

--- a/scripts/sounds.ps1
+++ b/scripts/sounds.ps1
@@ -13,11 +13,9 @@ param()
 
 Write-Output "Disabling Windows system sounds..."
 
-# Path to Default User profile
 $defaultUserHive = "C:\Users\Default\NTUSER.DAT"
 $tempKey = "HKU\DefaultUser"
 
-# Load the Default User registry hive
 Write-Output "Loading Default User registry hive..."
 try {
     Invoke-NativeCommand -FilePath "reg.exe" `
@@ -31,7 +29,6 @@ catch {
 try {
     $errorCount = 0
 
-    # Set sound scheme to None
     $schemePath = "Registry::$tempKey\AppEvents\Schemes"
     if (Test-Path $schemePath) {
         try {
@@ -44,7 +41,6 @@ try {
         }
     }
 
-    # Clear all individual sound events
     $basePath = "Registry::$tempKey\AppEvents\Schemes\Apps"
     if (Test-Path $basePath) {
         $apps = Get-ChildItem -Path $basePath -ErrorAction SilentlyContinue
@@ -77,13 +73,12 @@ try {
     }
 }
 finally {
-    # Force release of all registry handles
+    # Release registry handles before unloading the hive.
     [gc]::Collect()
     [gc]::WaitForPendingFinalizers()
     [gc]::Collect()
     Start-Sleep -Seconds 1
 
-    # Try to unload with retries
     $maxRetries = 5
     $retryCount = 0
     $unloaded = $false

--- a/scripts/time.ps1
+++ b/scripts/time.ps1
@@ -4,7 +4,6 @@ param()
 
 Write-Output "Configuring time settings..."
 
-# Set timezone to Amsterdam
 Write-Output "Setting timezone to W. Europe Standard Time (Amsterdam)..."
 try {
     Set-TimeZone -Id "W. Europe Standard Time" -ErrorAction Stop
@@ -14,7 +13,6 @@ catch {
     throw "Failed to set timezone: $($_.Exception.Message)"
 }
 
-# Set regional settings to Netherlands (nl-NL)
 Write-Output "Setting regional format to Dutch (Netherlands)..."
 try {
     Set-WinSystemLocale -SystemLocale "nl-NL" -ErrorAction Stop
@@ -23,7 +21,6 @@ try {
     Set-WinHomeLocation -GeoId 176 -ErrorAction Stop
     Write-Output "  Regional settings configured."
 
-    # Copy settings to new user profiles and welcome screen
     Write-Output "  Copying regional settings to default user profile..."
     Copy-UserInternationalSettingsToSystem -WelcomeScreen $true -NewUser $true -ErrorAction Stop
     Write-Output "  Regional settings will apply to new users."
@@ -32,7 +29,6 @@ catch {
     throw "Failed to set regional settings: $($_.Exception.Message)"
 }
 
-# Ensure the Windows Time Service is running
 Write-Output "Starting Windows Time Service..."
 try {
     if ((Get-Service -Name w32time).Status -ne 'Running') {
@@ -45,7 +41,6 @@ catch {
     throw "Failed to start time service: $($_.Exception.Message)"
 }
 
-# Configure the Windows Time Service to use the specified NTP servers
 Write-Output "Configuring NTP servers (nl.pool.ntp.org)..."
 $ntpServers = "0.nl.pool.ntp.org,1.nl.pool.ntp.org,2.nl.pool.ntp.org,3.nl.pool.ntp.org"
 
@@ -58,7 +53,6 @@ catch {
     Write-Warning $_.Exception.Message
 }
 
-# Forcing a resynchronization
 Write-Output "Syncing time..."
 try {
     Invoke-NativeCommand -FilePath "w32tm" `

--- a/scripts/updates.ps1
+++ b/scripts/updates.ps1
@@ -16,11 +16,9 @@ param()
 
 Write-Output "Checking for Windows updates..."
 
-# Create Windows Update Session
 $updateSession = New-Object -ComObject Microsoft.Update.Session
 $updateSearcher = $updateSession.CreateUpdateSearcher()
 
-# Search for updates
 Write-Output "Searching for available updates..."
 try {
     $searchResult = $updateSearcher.Search("IsInstalled=0 and Type='Software'")
@@ -41,7 +39,6 @@ foreach ($update in $updates) {
     Write-Output "  - $($update.Title)"
 }
 
-# Create update collection for download
 $updatesToDownload = New-Object -ComObject Microsoft.Update.UpdateColl
 foreach ($update in $updates) {
     if (-not $update.IsDownloaded) {
@@ -49,7 +46,6 @@ foreach ($update in $updates) {
     }
 }
 
-# Download updates
 if ($updatesToDownload.Count -gt 0) {
     Write-Output ""
     Write-Output "Downloading $($updatesToDownload.Count) update(s)..."
@@ -77,7 +73,6 @@ if ($updatesToDownload.Count -gt 0) {
     Write-Output "  All $downloadedCount update(s) downloaded."
 }
 
-# Create update collection for installation
 $updatesToInstall = New-Object -ComObject Microsoft.Update.UpdateColl
 foreach ($update in $updates) {
     if ($update.IsDownloaded) {
@@ -85,7 +80,6 @@ foreach ($update in $updates) {
     }
 }
 
-# Install updates
 if ($updatesToInstall.Count -gt 0) {
     Write-Output ""
     Write-Output "Installing $($updatesToInstall.Count) update(s)..."

--- a/scripts/users.ps1
+++ b/scripts/users.ps1
@@ -1,4 +1,3 @@
-# Define script parameters
 param (
     [string]$systemPurpose,
     [string]$systemOwnership,
@@ -94,7 +93,6 @@ if ($userName) {
     }
 }
 
-# Set registry values for auto-login if enabled
 $regPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
 if ($userName -and $enableAutoLogin) {
     Write-Output "Configuring auto-login for: $userName"
@@ -116,7 +114,6 @@ if ($userName -and $enableAutoLogin) {
     }
 }
 
-# Set maximum password age to unlimited
 Write-Output "Setting password policy (max age unlimited)..."
 Invoke-NativeCommand -FilePath "net.exe" `
     -Arguments @("accounts", "/maxpwage:unlimited") `

--- a/scripts/workgroupname.ps1
+++ b/scripts/workgroupname.ps1
@@ -1,4 +1,3 @@
-# Define script parameters
 param (
     [string]$computerName,
     [string]$workgroupName
@@ -6,11 +5,9 @@ param (
 
 Write-Output "Configuring computer name and workgroup..."
 
-# Fetch current system properties
 $currentComputerName = (Get-CimInstance -ClassName Win32_ComputerSystem).Name
 $currentWorkgroup = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
 
-# Check and update the computer name if necessary
 if ($currentComputerName -ne $computerName) {
     Write-Output "Changing computer name from $currentComputerName to $computerName..."
     try {
@@ -25,7 +22,6 @@ else {
     Write-Output "Computer name is already $computerName. No change needed."
 }
 
-# Check and update the workgroup if necessary
 if ($currentWorkgroup -ne $workgroupName) {
     Write-Output "Changing workgroup from $currentWorkgroup to $workgroupName..."
     try {


### PR DESCRIPTION
## Summary
- Add a scheduled policy auto-update task that reapplies the policy and AppLocker layers when the configured branch advances.
- Persist update state with applied/self-update SHA tracking, jittered triggers, backoff handling, and a local enabled flag.
- Tighten installer/update error handling, bundled binary validation, state writes, and deployment script comments.

## Validation
- PowerShell parse check
- PowerShell formatting check
- PSScriptAnalyzer
- JSON/XML/AJV validation
- URL check
- git diff --check