### PR TITLE
fix(users): centralize minimum password length

### DIFF
--- a/scripts/_common.ps1
+++ b/scripts/_common.ps1
@@ -3,6 +3,8 @@
     Shared helpers for Windows 11 baseline deployment scripts.
 #>
 
+$script:DeploymentMinimumPasswordLength = 14
+
 function Get-ZuidWestRoot {
     return (Join-Path $env:ProgramData "ZuidWest")
 }
@@ -286,8 +288,8 @@ function Test-LocalUserPassword {
         throw "A password is required when creating '$AccountName'."
     }
 
-    if ($plainPassword.Length -lt 8) {
-        throw "The password for '$AccountName' must be at least 8 characters."
+    if ($plainPassword.Length -lt $script:DeploymentMinimumPasswordLength) {
+        throw "The password for '$AccountName' must be at least $script:DeploymentMinimumPasswordLength characters."
     }
 
     $characterClasses = 0
@@ -359,7 +361,7 @@ function Read-DeploymentPassword {
     )
 
     Write-Host "Password requirements for '$AccountName':"
-    Write-Host "  - At least 8 characters"
+    Write-Host "  - At least $script:DeploymentMinimumPasswordLength characters"
     Write-Host "  - Characters from at least 3 of: uppercase, lowercase, numbers, symbols"
     Write-Host "  - Must not contain parts of the username"
 

--- a/scripts/users.ps1
+++ b/scripts/users.ps1
@@ -17,7 +17,7 @@ function ConvertTo-FriendlyPasswordError {
     )
 
     if ($ErrorRecord.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.InvalidPasswordException") {
-        return "Password was rejected by the local Windows password policy. Use at least 8 characters, 3 character groups, and do not include the username."
+        return "Password was rejected by the local Windows password policy. Use at least $script:DeploymentMinimumPasswordLength characters, 3 character groups, and do not include the username."
     }
     return $ErrorRecord.Exception.Message
 }


### PR DESCRIPTION
## Summary
- Centralize the deployment minimum password length in the shared helpers.
- Reuse the shared value in password validation and user-facing password policy messages.

## Validation
- PowerShell parse check
- PowerShell formatting check
- PSScriptAnalyzer
- git diff --check